### PR TITLE
Improve mobile admin layout

### DIFF
--- a/admin/src/components/Analytics.jsx
+++ b/admin/src/components/Analytics.jsx
@@ -126,74 +126,77 @@ export function Analytics({ links, currentView }) {
   return (
     <div className="space-y-6">
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4 sm:p-5">
-        <div className="grid gap-3 md:gap-4 grid-cols-1 lg:grid-cols-[1fr_auto] items-center">
-          <div className="flex items-center gap-3 flex-wrap">
+        <div className="grid gap-4 md:gap-5 grid-cols-1 lg:grid-cols-[1fr_auto] items-start">
+          <div className="flex flex-col sm:flex-row sm:flex-wrap gap-3 sm:gap-4">
             {/* Scope segmented control */}
-            <div
-              className="inline-flex rounded-md shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden shrink-0"
-              role="group"
-              aria-label="Scope"
-            >
-          <button
-            type="button"
-            onClick={() => setScope('all')}
-            className={`px-3 py-1.5 text-sm font-medium transition-colors ${
-              scope === 'all'
-                ? 'bg-blue-600 text-white'
-                : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'
-            }`}
-          >
-            All
-          </button>
-          <button
-            type="button"
-            onClick={() => setScope('shortcode')}
-            className={`px-3 py-1.5 text-sm font-medium transition-colors border-l border-gray-200 dark:border-gray-700 ${
-              scope === 'shortcode'
-                ? 'bg-blue-600 text-white'
-                : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'
-            }`}
-          >
-            Single
-          </button>
-        </div>
-
-            {/* Shortcode picker */}
-            {scope === 'shortcode' && (
-              <div className="flex items-center gap-3">
-                <label className="text-sm text-gray-600 dark:text-gray-300">Shortcode</label>
-                <select
-                  value={shortcode || ''}
-                  onChange={(e) => setShortcode(e.target.value)}
-                  className="px-2 py-1.5 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+            <div className="flex flex-col xs:flex-row xs:items-center gap-2 w-full sm:w-auto">
+              <div
+                className="flex rounded-md shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden w-full xs:w-auto"
+                role="group"
+                aria-label="Scope"
+              >
+                <button
+                  type="button"
+                  onClick={() => setScope('all')}
+                  className={`flex-1 px-3 py-1.5 text-sm font-medium transition-colors ${
+                    scope === 'all'
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'
+                  }`}
                 >
-                  {Object.keys(links).map((sc) => (
-                    <option key={sc} value={sc}>
-                      {sc}
-                    </option>
-                  ))}
-                </select>
+                  All
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setScope('shortcode')}
+                  className={`flex-1 px-3 py-1.5 text-sm font-medium transition-colors border-l border-gray-200 dark:border-gray-700 ${
+                    scope === 'shortcode'
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'
+                  }`}
+                >
+                  Single
+                </button>
               </div>
-            )}
+
+              {/* Shortcode picker */}
+              {scope === 'shortcode' && (
+                <div className="flex items-center gap-2 w-full xs:w-auto">
+                  <label className="text-xs xs:text-sm text-gray-600 dark:text-gray-300 shrink-0">Shortcode</label>
+                  <select
+                    value={shortcode || ''}
+                    onChange={(e) => setShortcode(e.target.value)}
+                    className="flex-1 xs:w-36 sm:w-40 px-2.5 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  >
+                    {Object.keys(links).map((sc) => (
+                      <option key={sc} value={sc}>
+                        {sc}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              )}
+            </div>
 
             {/* Date range with presets */}
-            <div className="flex items-center gap-2">
+            <div className="flex flex-col xs:flex-row xs:items-center gap-2 w-full sm:w-auto">
               <label className="hidden md:inline text-sm text-gray-600 dark:text-gray-300 shrink-0">Date</label>
-              <input
-                type="date"
-                value={range.from}
-                onChange={(e) => setRange((r) => ({ ...r, from: e.target.value }))}
-                className="w-36 sm:w-40 px-3 py-3 sm:py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
-              />
-              <span className="text-gray-500 shrink-0">to</span>
-              <input
-                type="date"
-                value={range.to}
-                onChange={(e) => setRange((r) => ({ ...r, to: e.target.value }))}
-                className="w-36 sm:w-40 px-3 py-3 sm:py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
-              />
+              <div className="grid grid-cols-1 xs:grid-cols-2 gap-2 w-full xs:w-auto">
+                <input
+                  type="date"
+                  value={range.from}
+                  onChange={(e) => setRange((r) => ({ ...r, from: e.target.value }))}
+                  className="w-full xs:w-36 sm:w-40 px-3 py-2.5 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+                <input
+                  type="date"
+                  value={range.to}
+                  onChange={(e) => setRange((r) => ({ ...r, to: e.target.value }))}
+                  className="w-full xs:w-36 sm:w-40 px-3 py-2.5 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
               <div
-                className="inline-flex rounded-md border border-gray-200 dark:border-gray-700 overflow-hidden ml-3 shrink-0"
+                className="flex xs:inline-flex rounded-md border border-gray-200 dark:border-gray-700 overflow-hidden w-full xs:w-auto"
                 role="group"
                 aria-label="Quick ranges"
               >
@@ -204,7 +207,7 @@ export function Analytics({ links, currentView }) {
                     const s = d.toISOString().slice(0, 10)
                     setRange({ from: s, to: s })
                   }}
-                  className="px-2 py-1 text-xs hover:bg-gray-50 dark:hover:bg-gray-700"
+                  className="flex-1 px-3 py-1.5 text-xs hover:bg-gray-50 dark:hover:bg-gray-700"
                 >
                   Today
                 </button>
@@ -218,7 +221,7 @@ export function Analytics({ links, currentView }) {
                       to: to.toISOString().slice(0, 10),
                     })
                   }}
-                  className="px-2 py-1 text-xs border-l border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700"
+                  className="flex-1 px-3 py-1.5 text-xs border-l border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700"
                 >
                   7d
                 </button>
@@ -232,7 +235,7 @@ export function Analytics({ links, currentView }) {
                       to: to.toISOString().slice(0, 10),
                     })
                   }}
-                  className="px-2 py-1 text-xs border-l border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700"
+                  className="flex-1 px-3 py-1.5 text-xs border-l border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700"
                 >
                   30d
                 </button>
@@ -240,12 +243,12 @@ export function Analytics({ links, currentView }) {
             </div>
 
             {/* Breakdown select */}
-            <div className="flex items-center gap-2 shrink-0">
+            <div className="flex flex-col xs:flex-row xs:items-center gap-2 w-full sm:w-auto">
               <label className="hidden md:inline text-sm text-gray-600 dark:text-gray-300 shrink-0">Breakdown</label>
               <select
                 value={dimension}
                 onChange={(e) => setDimension(e.target.value)}
-                className="w-[12rem] sm:w-[14rem] px-3 py-3 sm:py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full xs:w-[14rem] px-3 py-2.5 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
               >
                 <option value="ref">Referrer</option>
                 <option value="country">Country</option>
@@ -260,75 +263,92 @@ export function Analytics({ links, currentView }) {
             </div>
           </div>
 
-          <div className="flex items-center gap-2 sm:gap-3 justify-start lg:justify-end shrink-0">
+          <div className="flex flex-wrap gap-2 sm:gap-3 justify-start lg:justify-end shrink-0">
             {/* Export Button */}
             <button
-          onClick={async () => {
-            if (isExporting) return
+              onClick={async () => {
+                if (isExporting) return
 
-            setIsExporting(true)
-            try {
-              const params = new URLSearchParams()
-              if (scope === 'shortcode' && shortcode) {
-                params.set('shortcode', shortcode)
-              }
-              params.set('from', range.from)
-              params.set('to', range.to)
-              params.set('format', 'json')
+                setIsExporting(true)
+                try {
+                  const params = new URLSearchParams()
+                  if (scope === 'shortcode' && shortcode) {
+                    params.set('shortcode', shortcode)
+                  }
+                  params.set('from', range.from)
+                  params.set('to', range.to)
+                  params.set('format', 'json')
 
-              const response = await fetch(`/api/analytics/export?${params.toString()}`, {
-                headers: {
-                  Authorization: `Bearer ${localStorage.getItem('auth_token')}`,
-                },
-              })
+                  const response = await fetch(`/api/analytics/export?${params.toString()}`, {
+                    headers: {
+                      Authorization: `Bearer ${localStorage.getItem('auth_token')}`,
+                    },
+                  })
 
-              if (!response.ok) throw new Error('Export failed')
+                  if (!response.ok) throw new Error('Export failed')
 
-              const blob = await response.blob()
-              const url = window.URL.createObjectURL(blob)
-              const a = document.createElement('a')
-              a.style.display = 'none'
-              a.href = url
-              a.download = `analytics-${scope === 'shortcode' ? shortcode : 'global'}-${range.from}-${range.to}.json`
-              document.body.appendChild(a)
-              a.click()
-              window.URL.revokeObjectURL(url)
-              document.body.removeChild(a)
-            } catch (error) {
-              console.error('Export failed:', error)
-              alert('Failed to export analytics data')
-            } finally {
-              setIsExporting(false)
-            }
-          }}
-          disabled={isExporting}
-          className="inline-flex items-center px-3 py-1.5 border border-gray-300 dark:border-gray-600 text-sm font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-        >
-          <Download className="w-4 h-4 mr-1" />
-          {isExporting ? 'Exporting...' : 'Export'}
-        </button>
+                  const blob = await response.blob()
+                  const url = window.URL.createObjectURL(blob)
+                  const a = document.createElement('a')
+                  a.style.display = 'none'
+                  a.href = url
+                  a.download = `analytics-${scope === 'shortcode' ? shortcode : 'global'}-${range.from}-${range.to}.json`
+                  document.body.appendChild(a)
+                  a.click()
+                  window.URL.revokeObjectURL(url)
+                  document.body.removeChild(a)
+                } catch (error) {
+                  console.error('Export failed:', error)
+                  alert('Failed to export analytics data')
+                } finally {
+                  setIsExporting(false)
+                }
+              }}
+              disabled={isExporting}
+              className="inline-flex items-center justify-center px-3 py-2 text-sm font-medium border border-gray-300 dark:border-gray-600 rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors w-full xs:w-auto"
+            >
+              <Download className="w-4 h-4 mr-1" />
+              {isExporting ? 'Exporting...' : 'Export'}
+            </button>
 
             {/* Summary badges */}
             <div className="hidden sm:inline-flex items-center gap-3 text-sm">
-          {overview && (
-            <>
-              <span className="inline-flex items-center px-2 py-1 rounded-md bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 border border-blue-200 dark:border-blue-800">
-                Total:{' '}
-                <span className="ml-1 font-semibold">{overview.totalClicks.toLocaleString()}</span>
-              </span>
-              <span className="inline-flex items-center px-2 py-1 rounded-md bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-300 border border-green-200 dark:border-green-800">
-                Today:{' '}
-                <span className="ml-1 font-semibold">{overview.clicksToday.toLocaleString()}</span>
-              </span>
-            </>
-          )}
+              {overview && (
+                <>
+                  <span className="inline-flex items-center px-2 py-1 rounded-md bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 border border-blue-200 dark:border-blue-800">
+                    Total{' '}
+                    <span className="ml-1 font-semibold">{overview.totalClicks.toLocaleString()}</span>
+                  </span>
+                  <span className="inline-flex items-center px-2 py-1 rounded-md bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-300 border border-green-200 dark:border-green-800">
+                    Today{' '}
+                    <span className="ml-1 font-semibold">{overview.clicksToday.toLocaleString()}</span>
+                  </span>
+                </>
+              )}
             </div>
           </div>
         </div>
+
+        {overview && (
+          <div className="sm:hidden mt-3">
+            <div className="flex items-center gap-2 overflow-x-auto no-scrollbar text-xs">
+              <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 border border-blue-200 dark:border-blue-800">
+                <BarChart3 className="w-3.5 h-3.5" />
+                <span className="font-semibold">{overview.totalClicks.toLocaleString()}</span>
+                clicks
+              </span>
+              <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-300 border border-green-200 dark:border-green-800">
+                <Clock className="w-3.5 h-3.5" />
+                <span className="font-semibold">{overview.clicksToday.toLocaleString()}</span>
+                today
+              </span>
+            </div>
+          </div>
+        )}
       </div>
       {/* Stats Overview: scope-aware */}
       {scope === 'all' ? (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        <div className="grid grid-cols-1 xs:grid-cols-2 lg:grid-cols-4 gap-4">
           <StatCard
             icon={Globe}
             title="Total Links"
@@ -356,7 +376,7 @@ export function Analytics({ links, currentView }) {
           />
         </div>
       ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        <div className="grid grid-cols-1 xs:grid-cols-2 lg:grid-cols-4 gap-4">
           <StatCard
             icon={BarChart3}
             title="Link Clicks"

--- a/admin/src/components/LinkList.jsx
+++ b/admin/src/components/LinkList.jsx
@@ -142,6 +142,11 @@ const LinkList = memo(function LinkList({ links, onDelete, onUpdate, onBulkDelet
     })
   }
 
+  const formatNumber = (value) => {
+    const numeric = Number(value ?? 0)
+    return Number.isFinite(numeric) ? numeric.toLocaleString() : '0'
+  }
+
   if (linkEntries.length === 0) {
     return (
       <div
@@ -165,77 +170,79 @@ className="w-9 h-9 xs:w-10 xs:h-10 sm:w-12 sm:h-12 text-gray-400 dark:text-gray-
     <>
       {/* Bulk Operations Toolbar */}
       {linkEntries.length > 0 && (
-        <div className="mb-3 sm:mb-4 flex flex-col sm:flex-row items-start sm:items-center justify-between bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 px-3 sm:px-4 py-3 transition-colors space-y-2 sm:space-y-0">
-          <div className="flex items-center space-x-2 sm:space-x-4 flex-wrap gap-y-2">
-            <button
-              onClick={toggleBulkMode}
-              className={`px-3 py-2 sm:py-1 rounded-md text-sm font-medium transition-colors min-h-[44px] sm:min-h-[auto] ${
-                bulkMode
-                  ? 'bg-blue-600 text-white dark:bg-blue-500'
-                  : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
-              }`}
-              aria-pressed={bulkMode}
-            >
-              {bulkMode ? 'Exit Bulk Mode' : 'Bulk Mode'}
-            </button>
+        <div className="mb-3 sm:mb-4 bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 px-3 xs:px-4 py-3 sm:py-4 transition-colors">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 sm:gap-4">
+            <div className="flex flex-wrap items-center gap-2 sm:gap-3">
+              <button
+                onClick={toggleBulkMode}
+                className={`touch-target w-full xs:w-auto px-3 py-2 sm:py-1.5 rounded-md text-sm font-medium transition-colors flex items-center justify-center ${
+                  bulkMode
+                    ? 'bg-blue-600 text-white dark:bg-blue-500'
+                    : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
+                }`}
+                aria-pressed={bulkMode}
+              >
+                {bulkMode ? 'Exit Bulk Mode' : 'Bulk Mode'}
+              </button>
+
+              {bulkMode && (
+                <>
+                  <span className="text-sm text-gray-600 dark:text-gray-300 w-full xs:w-auto">
+                    {selectedLinks.size} of {linkEntries.length} selected
+                  </span>
+                  <button
+                    onClick={selectAllLinks}
+                    className="touch-target px-3 py-1.5 rounded-md text-sm font-medium text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 disabled:opacity-50 disabled:cursor-not-allowed bg-transparent hover:bg-blue-50/60 dark:hover:bg-blue-900/20 transition-colors w-full xs:w-auto"
+                    disabled={selectedLinks.size === linkEntries.length}
+                  >
+                    Select All
+                  </button>
+                  <button
+                    onClick={clearSelection}
+                    className="touch-target px-3 py-1.5 rounded-md text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 disabled:opacity-50 disabled:cursor-not-allowed bg-transparent hover:bg-gray-100/70 dark:hover:bg-gray-700/60 transition-colors w-full xs:w-auto"
+                    disabled={selectedLinks.size === 0}
+                  >
+                    Clear
+                  </button>
+                </>
+              )}
+            </div>
 
             {bulkMode && (
-              <>
-                <span className="text-sm text-gray-600 dark:text-gray-300">
-                  {selectedLinks.size} of {linkEntries.length} selected
-                </span>
+              <div className="flex flex-wrap gap-2 sm:gap-3 w-full sm:w-auto sm:justify-end">
                 <button
-                  onClick={selectAllLinks}
-                  className="text-sm text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 disabled:opacity-50 py-2 px-1"
-                  disabled={selectedLinks.size === linkEntries.length}
+                  onClick={() => setBulkImportOpen(true)}
+                  className="touch-target inline-flex items-center justify-center px-3 py-2 sm:py-1.5 border border-gray-300 dark:border-gray-600 rounded-md text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors w-full xs:w-auto"
+                  title="Bulk import links from CSV"
                 >
-                  Select All
+                  <Upload className="w-4 h-4 mr-1" />
+                  Import CSV
                 </button>
                 <button
-                  onClick={clearSelection}
-                  className="text-sm text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-gray-100 disabled:opacity-50 py-2 px-1"
+                  onClick={handleExportSelected}
+                  className="touch-target inline-flex items-center justify-center px-3 py-2 sm:py-1.5 border border-gray-300 dark:border-gray-600 rounded-md text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed w-full xs:w-auto"
+                  title="Export selected links to CSV"
                   disabled={selectedLinks.size === 0}
                 >
-                  Clear
+                  <Download className="w-4 h-4 mr-1" />
+                  Export
                 </button>
-              </>
+                <button
+                  onClick={handleBulkDelete}
+                  className="touch-target inline-flex items-center justify-center px-3 py-2 sm:py-1.5 border border-red-300 dark:border-red-500 rounded-md text-sm font-medium text-red-700 dark:text-red-400 bg-white dark:bg-gray-800 hover:bg-red-50 dark:hover:bg-red-900/20 focus:outline-none focus:ring-2 focus:ring-red-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed w-full xs:w-auto"
+                  title={
+                    selectedLinks.size > 0
+                      ? `Delete ${selectedLinks.size} selected links`
+                      : 'Delete selected links'
+                  }
+                  disabled={selectedLinks.size === 0}
+                >
+                  <Trash2 className="w-4 h-4 mr-1" />
+                  Delete{selectedLinks.size > 0 ? ` (${selectedLinks.size})` : ''}
+                </button>
+              </div>
             )}
           </div>
-
-          {bulkMode && (
-            <div className="flex flex-col sm:flex-row gap-2 sm:gap-0 sm:items-center sm:space-x-2">
-              <button
-                onClick={() => setBulkImportOpen(true)}
-                className="inline-flex items-center justify-center px-3 py-2 sm:py-1 border border-gray-300 dark:border-gray-600 rounded-md text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors min-h-[44px] sm:min-h-[auto]"
-                title="Bulk import links from CSV"
-              >
-                <Upload className="w-4 h-4 mr-1" />
-                Import CSV
-              </button>
-              <button
-                onClick={handleExportSelected}
-                className="inline-flex items-center justify-center px-3 py-2 sm:py-1 border border-gray-300 dark:border-gray-600 rounded-md text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors disabled:opacity-50 min-h-[44px] sm:min-h-[auto]"
-                title="Export selected links to CSV"
-                disabled={selectedLinks.size === 0}
-              >
-                <Download className="w-4 h-4 mr-1" />
-                Export
-              </button>
-              <button
-                onClick={handleBulkDelete}
-                className="inline-flex items-center justify-center px-3 py-2 sm:py-1 border border-red-300 dark:border-red-500 rounded-md text-sm font-medium text-red-700 dark:text-red-400 bg-white dark:bg-gray-800 hover:bg-red-50 dark:hover:bg-red-900/20 focus:outline-none focus:ring-2 focus:ring-red-500 transition-colors disabled:opacity-50 min-h-[44px] sm:min-h-[auto]"
-                title={
-                  selectedLinks.size > 0
-                    ? `Delete ${selectedLinks.size} selected links`
-                    : 'Delete selected links'
-                }
-                disabled={selectedLinks.size === 0}
-              >
-                <Trash2 className="w-4 h-4 mr-1" />
-                Delete{selectedLinks.size > 0 ? ` (${selectedLinks.size})` : ''}
-              </button>
-            </div>
-          )}
         </div>
       )}
 
@@ -258,12 +265,12 @@ className="w-9 h-9 xs:w-10 xs:h-10 sm:w-12 sm:h-12 text-gray-400 dark:text-gray-
                 }`}
                 role="listitem"
               >
-                <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
+                <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
                   {bulkMode && (
-                    <div className="flex items-center mr-4 mt-1">
+                    <div className="flex items-start sm:mr-4">
                       <button
                         onClick={() => toggleLinkSelection(shortcode)}
-                        className="p-2 sm:p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 min-h-[44px] min-w-[44px] sm:min-h-[auto] sm:min-w-[auto] flex items-center justify-center"
+                        className="touch-target p-2 sm:p-1 rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 flex items-center justify-center"
                         aria-label={`${selectedLinks.has(shortcode) ? 'Unselect' : 'Select'} link ${shortcode}`}
                       >
                         {selectedLinks.has(shortcode) ? (
@@ -274,113 +281,124 @@ className="w-9 h-9 xs:w-10 xs:h-10 sm:w-12 sm:h-12 text-gray-400 dark:text-gray-
                       </button>
                     </div>
                   )}
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center space-x-2 mb-2 sm:mb-2">
-                      <code
-                        className="px-2 py-1 bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300 text-sm font-mono rounded break-all sm:break-normal"
-                        aria-label={`Short URL: ${workerHost()}/${shortcode}`}
-                      >
-                        {workerHost()}/{shortcode}
-                      </code>
-                      <button
-                        onClick={() => copyToClipboard(shortcode)}
-                        className="p-2 sm:p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 rounded min-h-[44px] min-w-[44px] sm:min-h-[auto] sm:min-w-[auto] flex items-center justify-center flex-shrink-0"
-                        aria-label={`Copy link for ${shortcode} to clipboard`}
-                      >
-                        <Copy className="w-4 h-4" aria-hidden="true" />
-                      </button>
+
+                  <div className="flex-1 min-w-0 space-y-3">
+                    <div className="flex flex-col xs:flex-row xs:items-start xs:justify-between gap-2">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <code
+                          className="px-2 py-1 bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300 text-sm font-mono rounded break-all xs:break-normal"
+                          aria-label={`Short URL: ${workerHost()}/${shortcode}`}
+                        >
+                          {workerHost()}/{shortcode}
+                        </code>
+                        <button
+                          onClick={() => copyToClipboard(shortcode)}
+                          className="touch-target p-2 sm:p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 rounded-md flex items-center justify-center"
+                          aria-label={`Copy link for ${shortcode} to clipboard`}
+                        >
+                          <Copy className="w-4 h-4" aria-hidden="true" />
+                        </button>
+                      </div>
                       {copiedShortcode === shortcode && (
-                        <span className="text-xs text-green-600 dark:text-green-400" role="status" aria-live="polite">
+                        <span className="text-xs xs:text-sm text-green-600 dark:text-green-400" role="status" aria-live="polite">
                           Copied!
                         </span>
                       )}
                     </div>
 
-                    <div className="flex items-start space-x-2 mb-2">
+                    <div className="flex items-start gap-2">
                       <ExternalLink className="w-4 h-4 text-gray-400 flex-shrink-0 mt-0.5" />
                       <a
                         href={link.url}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="text-gray-900 dark:text-gray-100 hover:text-blue-600 dark:hover:text-blue-400 break-all sm:break-normal sm:truncate transition-colors text-sm sm:text-base"
+                        className="text-gray-900 dark:text-gray-100 hover:text-blue-600 dark:hover:text-blue-400 break-words transition-colors text-sm xs:text-base leading-snug"
                       >
                         {link.url}
                       </a>
                     </div>
 
                     {link.description && (
-                      <p className="text-sm text-gray-600 dark:text-gray-400 mb-2">{link.description}</p>
+                      <p className="text-sm text-gray-600 dark:text-gray-400 leading-snug">{link.description}</p>
                     )}
 
-                    {/* Tags and badges - mobile scrollable */}
-                    <div className="flex items-center gap-2 mb-3 overflow-x-auto no-scrollbar ios-momentum whitespace-nowrap sm:flex-wrap sm:whitespace-normal">
+                    <div className="flex flex-wrap items-center gap-2 text-xs">
                       {Array.isArray(link.tags) &&
                         link.tags.map((tag) => (
                           <span
                             key={tag}
-                            className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-200 flex-shrink-0"
+                            className="inline-flex items-center px-2 py-0.5 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-200"
                           >
                             {tag}
                           </span>
                         ))}
                       {link.archived && (
-                        <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-300 flex-shrink-0">
+                        <span className="inline-flex items-center px-2 py-0.5 rounded-full bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-300">
                           Archived
                         </span>
                       )}
                       {link.passwordEnabled && (
-                        <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-purple-100 dark:bg-purple-900/30 text-purple-800 dark:text-purple-300 flex-shrink-0">
+                        <span className="inline-flex items-center px-2 py-0.5 rounded-full bg-purple-100 dark:bg-purple-900/30 text-purple-800 dark:text-purple-300">
                           <Lock className="w-3 h-3 mr-1" />
                           Protected
                         </span>
                       )}
                     </div>
 
-                    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500 dark:text-gray-400">
-                      <div className="flex items-center space-x-1">
-                        <BarChart3 className="w-3 h-3" />
-                        <span>{link.clicks || 0} clicks</span>
+                    <div className="grid grid-cols-1 xs:grid-cols-2 gap-x-4 gap-y-2 text-xs text-gray-500 dark:text-gray-400 sm:flex sm:flex-wrap sm:items-center sm:gap-x-3 sm:gap-y-1">
+                      <div className="flex items-center gap-1">
+                        <BarChart3 className="w-3.5 h-3.5" />
+                        <span className="font-semibold text-gray-900 dark:text-gray-100">{formatNumber(link.clicks)}</span>
+                        <span>clicks</span>
                       </div>
-                      <span>Created {formatDate(link.created)}</span>
+                      <div className="flex items-center gap-1">
+                        <span className="font-medium text-gray-600 dark:text-gray-300">Created</span>
+                        <span className="text-gray-700 dark:text-gray-200">{formatDate(link.created)}</span>
+                      </div>
                       {link.updated !== link.created && (
-                        <span>Updated {formatDate(link.updated)}</span>
+                        <div className="flex items-center gap-1">
+                          <span className="font-medium text-gray-600 dark:text-gray-300">Updated</span>
+                          <span className="text-gray-700 dark:text-gray-200">{formatDate(link.updated)}</span>
+                        </div>
                       )}
-                      <span className="px-2 py-1 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded text-xs">
-                        {link.redirectType || 301}
-                      </span>
-                      {link.activatesAt && (
-                        <span
-                          title="Activates"
-                          className="px-2 py-1 bg-green-50 dark:bg-green-900/30 text-green-700 dark:text-green-300 rounded text-xs"
-                        >
-                          Starts {formatDate(link.activatesAt)}
+                      <div className="flex items-center gap-1">
+                        <span className="font-medium text-gray-600 dark:text-gray-300">Type</span>
+                        <span className="inline-flex items-center px-2 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 font-medium">
+                          {link.redirectType || 301}
                         </span>
+                      </div>
+                      {link.activatesAt && (
+                        <div className="flex items-center gap-1">
+                          <span className="font-medium text-gray-600 dark:text-gray-300">Starts</span>
+                          <span className="text-gray-700 dark:text-gray-200">{formatDate(link.activatesAt)}</span>
+                        </div>
                       )}
                       {link.expiresAt && (
-                        <span
-                          title="Expires"
-                          className="px-2 py-1 bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-300 rounded text-xs"
-                        >
-                          Ends {formatDate(link.expiresAt)}
-                        </span>
+                        <div className="flex items-center gap-1">
+                          <span className="font-medium text-gray-600 dark:text-gray-300">Ends</span>
+                          <span className="text-gray-700 dark:text-gray-200">{formatDate(link.expiresAt)}</span>
+                        </div>
                       )}
                     </div>
                   </div>
 
                   {/* Mobile kebab menu */}
-                  <div className="sm:hidden relative self-start mt-1" role="group" aria-label={`Actions for ${shortcode}`}>
+                  <div className="sm:hidden relative self-start" role="group" aria-label={`Actions for ${shortcode}`}>
                     <button
                       onClick={() => setOpenMenuFor((prev) => (prev === shortcode ? null : shortcode))}
-                      className="p-2 min-h-[44px] min-w-[44px] text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded flex items-center justify-center"
+                      className="touch-target p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded-md flex items-center justify-center"
                       aria-label={`More actions for ${shortcode}`}
                       aria-expanded={openMenuFor === shortcode}
                     >
                       <MoreVertical className="w-5 h-5" />
                     </button>
-{openMenuFor === shortcode && (
-<div className="absolute right-0 mt-2 w-56 max-h-[60vh] overflow-auto bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md shadow-lg z-20 p-1" role="menu">
+                    {openMenuFor === shortcode && (
+                      <div className="absolute right-0 mt-2 w-56 max-h-[60vh] overflow-auto bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md shadow-lg z-20 p-1" role="menu">
                         <button
-                          onClick={() => { setEditingLink({ shortcode, ...link }); setOpenMenuFor(null) }}
+                          onClick={() => {
+                            setEditingLink({ shortcode, ...link })
+                            setOpenMenuFor(null)
+                          }}
                           className="w-full text-left px-4 py-3 min-h-[44px] text-sm text-gray-900 dark:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-700 flex items-center"
                           role="menuitem"
                         >
@@ -388,7 +406,10 @@ className="w-9 h-9 xs:w-10 xs:h-10 sm:w-12 sm:h-12 text-gray-400 dark:text-gray-
                           Edit
                         </button>
                         <button
-                          onClick={() => { onUpdate(shortcode, { archived: !link.archived }); setOpenMenuFor(null) }}
+                          onClick={() => {
+                            onUpdate(shortcode, { archived: !link.archived })
+                            setOpenMenuFor(null)
+                          }}
                           className="w-full text-left px-4 py-3 min-h-[44px] text-sm text-gray-900 dark:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-700 flex items-center"
                           role="menuitem"
                         >
@@ -400,7 +421,10 @@ className="w-9 h-9 xs:w-10 xs:h-10 sm:w-12 sm:h-12 text-gray-400 dark:text-gray-
                           {link.archived ? 'Unarchive' : 'Archive'}
                         </button>
                         <button
-                          onClick={() => { handleShowQRCode(shortcode, link); setOpenMenuFor(null) }}
+                          onClick={() => {
+                            handleShowQRCode(shortcode, link)
+                            setOpenMenuFor(null)
+                          }}
                           className="w-full text-left px-4 py-3 min-h-[44px] text-sm text-gray-900 dark:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-700 flex items-center"
                           role="menuitem"
                         >
@@ -408,7 +432,10 @@ className="w-9 h-9 xs:w-10 xs:h-10 sm:w-12 sm:h-12 text-gray-400 dark:text-gray-
                           QR Code
                         </button>
                         <button
-                          onClick={() => { handleDeleteClick(shortcode); setOpenMenuFor(null) }}
+                          onClick={() => {
+                            handleDeleteClick(shortcode)
+                            setOpenMenuFor(null)
+                          }}
                           className="w-full text-left px-4 py-3 min-h-[44px] text-sm text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 flex items-center"
                           role="menuitem"
                         >
@@ -421,7 +448,7 @@ className="w-9 h-9 xs:w-10 xs:h-10 sm:w-12 sm:h-12 text-gray-400 dark:text-gray-
 
                   {/* Desktop action icons */}
                   <div
-                    className="hidden sm:flex items-center space-x-1 mt-3 sm:mt-0 sm:ml-4 self-start sm:self-auto"
+                    className="hidden sm:flex items-center space-x-1 mt-2 sm:mt-0 sm:ml-4 self-start sm:self-auto"
                     role="group"
                     aria-label={`Actions for ${shortcode}`}
                   >

--- a/admin/src/components/StatCard.jsx
+++ b/admin/src/components/StatCard.jsx
@@ -1,5 +1,5 @@
 export function StatCard({ icon: Icon, title, value, subtitle, color }) {
-  const safeColor = color || 'text-gray-600 dark:text-gray-400'
+  const safeColor = color || 'text-gray-600 dark:text-gray-400';
 
   return (
     <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4 xs:p-5 sm:p-6 transition-colors h-full">

--- a/admin/src/components/StatCard.jsx
+++ b/admin/src/components/StatCard.jsx
@@ -1,25 +1,33 @@
 export function StatCard({ icon: Icon, title, value, subtitle, color }) {
-  const safeColor = color || 'text-gray-600 dark:text-gray-400';
-  
+  const safeColor = color || 'text-gray-600 dark:text-gray-400'
+
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6 transition-colors">
-      <div className="flex items-start">
-        <div className={`flex-shrink-0 p-2 rounded-lg ${safeColor.includes('blue') ? 'bg-blue-50 dark:bg-blue-900/20' : 
-          safeColor.includes('green') ? 'bg-green-50 dark:bg-green-900/20' : 
-          safeColor.includes('purple') ? 'bg-purple-50 dark:bg-purple-900/20' : 
-          safeColor.includes('orange') ? 'bg-orange-50 dark:bg-orange-900/20' : 
-          'bg-gray-50 dark:bg-gray-900/20'}`}>
-          <Icon className={`w-5 h-5 ${safeColor}`} />
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4 xs:p-5 sm:p-6 transition-colors h-full">
+      <div className="flex items-start gap-3">
+        <div
+          className={`flex-shrink-0 p-1.5 sm:p-2 rounded-lg ${
+            safeColor.includes('blue')
+              ? 'bg-blue-50 dark:bg-blue-900/20'
+              : safeColor.includes('green')
+                ? 'bg-green-50 dark:bg-green-900/20'
+                : safeColor.includes('purple')
+                  ? 'bg-purple-50 dark:bg-purple-900/20'
+                  : safeColor.includes('orange')
+                    ? 'bg-orange-50 dark:bg-orange-900/20'
+                    : 'bg-gray-50 dark:bg-gray-900/20'
+          }`}
+        >
+          <Icon className={`w-4 h-4 sm:w-5 sm:h-5 ${safeColor}`} />
         </div>
-        <div className="ml-4 flex-1 min-w-0">
-          <p className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1">
+        <div className="flex-1 min-w-0">
+          <p className="text-[11px] xs:text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1">
             {title}
           </p>
-          <p className="text-2xl font-bold text-gray-900 dark:text-white mb-1">
+          <p className="text-xl xs:text-2xl font-bold text-gray-900 dark:text-white mb-0.5">
             {value}
           </p>
           {subtitle && (
-            <p className="text-sm text-gray-500 dark:text-gray-400">
+            <p className="text-xs xs:text-sm text-gray-500 dark:text-gray-400">
               {subtitle}
             </p>
           )}


### PR DESCRIPTION
## Summary
- reflow analytics controls and badges for smaller breakpoints and add mobile summaries
- redesign link list bulk toolbar and cards for responsive spacing and touch targets
- adjust stat cards to scale typography and padding across screen sizes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9b92f1aac832885ce946d12db0433