### PR TITLE
Sprint 2b: perf + security polish + identity cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,6 @@ jobs:
         # exact same runner that owns prod migrations also owns staging.
         env:
           D1_DATABASE_NAME: mack-link-staging
-          AUTHORIZED_USER: mackhaymond
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: npm -w worker run db:apply

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,12 +148,6 @@ jobs:
           workingDirectory: worker
           command: deploy --env staging
           wranglerVersion: ${{ env.WRANGLER_VERSION }}
-        env:
-          # Staging runs in AUTH_DISABLED=true mode (see env.staging.vars in
-          # wrangler.jsonc) so a real OAuth client is not required. JWT_SECRET
-          # must still be present for cookie signing; reuse the prod secret
-          # rather than minting a separate staging one to keep secret sprawl low.
-          JWT_SECRET: ${{ secrets.JWT_SECRET }}
 
       - name: Smoke test staging
         if: steps.check.outputs.skip != 'true' && steps.check_subdomain.outputs.skip != 'true'

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -120,8 +120,13 @@ silently. Bump together.
   for not-yours to avoid existence enumeration
 - Password-protected links: PBKDF2 100k SHA-256, constant-time compare,
   session token in httpOnly cookie scoped to `/{shortcode}`
-- Rate limits: 50/hr create, 200/hr update/delete, 50/hr bulk ops,
-  10/min password verify per (shortcode + IP)
+- Rate limits: Cloudflare native Rate-Limit binding (B1, Sprint 2b).
+  10/min create, 30/min update/delete, 10/min bulk ops, 10/min password
+  verify per (shortcode + IP). Counters are **per Cloudflare location**
+  (eventually consistent across PoPs), not global — a coordinated
+  attacker hitting multiple PoPs could exceed the per-PoP limit. Accepted
+  trade-off at this scale; the alternative (Durable Object-backed global
+  counter) trades latency for global accuracy.
 - Standard security headers on every response: HSTS (preload), nosniff,
   X-Frame-Options=DENY, Referrer-Policy=strict-origin-when-cross-origin,
   Permissions-Policy=interest-cohort=(), CSP for HTML

--- a/WARP.md
+++ b/WARP.md
@@ -263,6 +263,7 @@ This project runs as a single Cloudflare Worker that serves an embedded React ad
 ### Performance Optimizations
 - Edge-first architecture with Cloudflare Workers
 - Efficient D1 queries with proper indexing
+- D1 Sessions API + read replication (B2, Sprint 2b): `/api/*` requests are wrapped in `env.DB.withSession(bookmark)`; the admin client round-trips an `x-d1-bookmark` request/response header to keep read-after-write consistency across requests while still reading from the nearest replica. Hot-path (redirect/analytics) intentionally bypasses sessions — those paths are eventually consistent by design. Read replication itself is a dashboard toggle (D1 → Settings → Enable Read Replication); the code path works unchanged whether replication is on or off.
 - Frontend code splitting and lazy loading
 - Optimized bundle size with Vite
 - Caching headers for static assets

--- a/docs/API.md
+++ b/docs/API.md
@@ -14,20 +14,33 @@ https://YOUR_DOMAIN.com
 
 ## 🔐 Authentication
 
-Mack.link uses **GitHub OAuth** for authentication with secure session cookies:
+Authentication is handled by **Cloudflare Access** at the edge. The Worker
+verifies the `Cf-Access-Jwt-Assertion` header that Access injects on
+proxied requests; it doesn't issue its own session cookies or run an
+OAuth flow.
 
-### For Web Applications (Recommended)
-The admin interface uses HttpOnly session cookies automatically. No manual token handling required.
+For the full path-coverage table (which paths Access protects vs.
+bypasses, the dev-bypass model, and the JWT verification logic), see
+[SECURITY.md](../SECURITY.md).
 
-### For API Access (Legacy)
-You can still use GitHub personal access tokens for direct API access:
+For browser-facing flows: the admin SPA reads identity from
+`/cdn-cgi/access/get-identity` after Access logs the user in. No
+session cookie handling is required in the client.
+
+For automated API access: you need a Cloudflare Access **service token**
+(client ID + client secret) issued from the Zero Trust dashboard. Pass
+them as `CF-Access-Client-Id` and `CF-Access-Client-Secret` headers:
 
 ```bash
-curl -H "Authorization: Bearer your_github_token" \
-     https://YOUR_DOMAIN.com/api/links
+curl -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
+     -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
+     https://link.mackhaymond.co/api/links
 ```
 
-> ⚠️ **Security Note**: Session cookies are more secure as tokens never leave the server.
+The Worker's previous GitHub OAuth flow (`GET /api/auth/github`,
+`GET /admin/auth/callback`) was removed in Sprint 2a. The only
+auth-related endpoint left is `POST /api/auth/logout`, which returns
+the Cloudflare Access logout URL for the SPA to navigate to.
 
 ---
 
@@ -77,64 +90,27 @@ Submit password for protected links.
 
 ## 🔑 Authentication Endpoints
 
-### GitHub OAuth Flow
-
-#### `GET /api/auth/github`
-
-Starts the GitHub OAuth authentication process.
-
-**Query Parameters:**
-- `redirect_uri` (optional) - Where to redirect after OAuth completion
-
-**Response:**
-- `302` - Redirects to GitHub OAuth page
-
-**Example:**
-```bash
-curl "https://YOUR_DOMAIN.com/api/auth/github"
-# Redirects to GitHub for authorization
-```
-
-#### `GET /admin/auth/callback`
-
-Handles the OAuth callback from GitHub (automatic).
-
-**Query Parameters:**
-- `code` - OAuth authorization code (provided by GitHub)
-- `state` - OAuth state parameter
-
-**Success Response:**
-```json
-{
-  "user": {
-    "login": "your-username",
-    "avatar_url": "https://avatars.githubusercontent.com/u/123456",
-    "id": 123456,
-    "name": "Your Name"
-  }
-}
-```
-
-**Error Response:**
-```json
-{
-  "error": "access_denied",
-  "error_description": "Only authorized users can access this service."
-}
-```
-
 #### `POST /api/auth/logout`
 
-Sign out and clear the session cookie.
+Returns the Cloudflare Access logout URL. The admin SPA navigates to
+this URL to clear the `CF_Authorization` cookie and bounce the user
+back to the Access login page.
 
 **Response:**
-- `200` - Successfully logged out
+```json
+{
+  "logout": "https://YOUR-TEAM.cloudflareaccess.com/cdn-cgi/access/logout"
+}
+```
 
 ---
 
 ## 🔐 Protected API Endpoints
 
-All endpoints below require authentication via session cookie or GitHub token.
+All endpoints below require a valid Cloudflare Access JWT (verified by the
+Worker via `Cf-Access-Jwt-Assertion`) or a valid Access service token
+(`CF-Access-Client-Id` + `CF-Access-Client-Secret`). See the
+Authentication section above.
 
 ### Link Management
 
@@ -433,9 +409,10 @@ interface Link {
 ### User Object
 ```typescript
 interface User {
-  login: string;                  // GitHub username
-  id: number;                     // GitHub user ID
-  avatar_url: string;             // Profile picture URL
+  login: string;                  // Email address (full) — post-Sprint-2b
+  email: string;                  // Same as login
+  id: string;                     // Cloudflare Access subject claim (`sub`)
+  avatar_url: string;             // Profile picture URL (may be empty)
   name?: string;                  // Display name
 }
 ```

--- a/worker/scripts/migrate.mjs
+++ b/worker/scripts/migrate.mjs
@@ -292,7 +292,11 @@ function main() {
 		const programmatic = PROGRAMMATIC_STEPS[f];
 		if (programmatic) programmatic();
 		const sql = readFileSync(join(MIGRATIONS_DIR, f), 'utf8');
-		if (sql.trim().length > 0) execSql(sql);
+		// Skip comment-only migrations (programmatic-only steps like 006 use
+		// the .sql file as a documentation marker). Strip line comments and
+		// whitespace; if anything's left, send the original to wrangler.
+		const stripped = sql.replace(/^\s*--.*$/gm, '').trim();
+		if (stripped.length > 0) execSql(sql);
 		execSql(`INSERT INTO migrations (id, applied_at) VALUES ('${f}', ${Date.now()});`);
 		ran++;
 	}

--- a/worker/scripts/migrate.mjs
+++ b/worker/scripts/migrate.mjs
@@ -210,28 +210,46 @@ function maybeAddOwnerIdToLinks() {
  * to the post-Access email-based identity. See 006_owner_id_email.sql for
  * the full design rationale.
  *
- * Idempotent: skips with a log line if OWNER_EMAIL isn't set OR if the
- * old row doesn't exist (already migrated / fresh install).
+ * Two invocation modes:
+ *   1. OWNER_EMAIL=user@example.com
+ *        -> renames `gh:user` to `user@example.com`
+ *        -> the typical prod path
+ *   2. OLD_OWNER_ID=gh:ai-dev NEW_OWNER_ID=ai-dev
+ *        -> raw rename, no email validation
+ *        -> escape hatch for synthetic identities (local dev's mock
+ *           'ai-dev' user, test fixtures) or any non-email scheme
+ *
+ * Mode 1 also accepts OLD_OWNER_ID to override the `gh:<localpart>` guess
+ * when legacy data has a non-matching shape (e.g. `gh:mackhaymond` while
+ * the new email is mack.haymond@icloud.com).
+ *
+ * Idempotent: skips with a log line if no rename args are provided OR if
+ * the old row doesn't exist (already migrated / fresh install).
  *
  * Safe edge cases:
  *   - Target row already exists (partial prior migration): point links
  *     at the new row and delete the old user row instead of UPDATE on PK.
- *   - OLD_OWNER_ID env var overrides the default `gh:<localpart>` guess
- *     so existing prod data with a different legacy shape (e.g.
- *     `gh:mackhaymond` while OWNER_EMAIL=mack.haymond@icloud.com) can
- *     still be renamed without us hardcoding assumptions.
  */
 function maybeRenameOwnerIdToEmail() {
 	const email = process.env.OWNER_EMAIL;
-	if (!email) {
-		console.log('  · OWNER_EMAIL not set, skipping owner_id rename (set it to migrate legacy gh:* rows)');
+	const explicitOld = process.env.OLD_OWNER_ID;
+	const explicitNew = process.env.NEW_OWNER_ID;
+
+	let oldId;
+	let newId;
+	if (explicitOld && explicitNew) {
+		oldId = explicitOld;
+		newId = explicitNew;
+	} else if (email) {
+		if (!email.includes('@')) {
+			throw new Error(`OWNER_EMAIL must be a valid email, got: ${email}`);
+		}
+		oldId = explicitOld || `gh:${email.split('@')[0]}`;
+		newId = email;
+	} else {
+		console.log('  · neither OWNER_EMAIL nor OLD_OWNER_ID+NEW_OWNER_ID set, skipping owner_id rename');
 		return;
 	}
-	if (!email.includes('@')) {
-		throw new Error(`OWNER_EMAIL must be a valid email, got: ${email}`);
-	}
-	const expectedLocalPart = email.split('@')[0];
-	const oldId = process.env.OLD_OWNER_ID || `gh:${expectedLocalPart}`;
 
 	const result = execSqlJson(`SELECT id FROM users WHERE id = '${oldId}';`);
 	const oldRows = (result?.[0]?.results) || [];
@@ -240,18 +258,19 @@ function maybeRenameOwnerIdToEmail() {
 		return;
 	}
 
-	const targetResult = execSqlJson(`SELECT id FROM users WHERE id = '${email}';`);
+	const targetResult = execSqlJson(`SELECT id FROM users WHERE id = '${newId}';`);
 	const targetExists = ((targetResult?.[0]?.results) || []).length > 0;
 	const now = Date.now();
 
 	if (targetExists) {
-		console.log(`  + rename owner_id ${oldId} -> ${email} (target row exists; merging)`);
-		execSql(`UPDATE links SET owner_id = '${email}' WHERE owner_id = '${oldId}';`);
+		console.log(`  + rename owner_id ${oldId} -> ${newId} (target row exists; merging)`);
+		execSql(`UPDATE links SET owner_id = '${newId}' WHERE owner_id = '${oldId}';`);
 		execSql(`DELETE FROM users WHERE id = '${oldId}';`);
 	} else {
-		console.log(`  + rename owner_id ${oldId} -> ${email}`);
-		execSql(`UPDATE users SET id = '${email}', email = '${email}', updated_at = ${now} WHERE id = '${oldId}';`);
-		execSql(`UPDATE links SET owner_id = '${email}' WHERE owner_id = '${oldId}';`);
+		console.log(`  + rename owner_id ${oldId} -> ${newId}`);
+		const emailUpdate = newId.includes('@') ? `, email = '${newId}'` : '';
+		execSql(`UPDATE users SET id = '${newId}'${emailUpdate}, updated_at = ${now} WHERE id = '${oldId}';`);
+		execSql(`UPDATE links SET owner_id = '${newId}' WHERE owner_id = '${oldId}';`);
 	}
 }
 

--- a/worker/scripts/migrate.mjs
+++ b/worker/scripts/migrate.mjs
@@ -165,10 +165,16 @@ function maybeAddExpiresAtToCounters() {
 }
 
 function maybeAddOwnerIdToLinks() {
+	// B4b (Sprint 2b): prefer OWNER_EMAIL for the backfill identity. Fresh
+	// installs that already have the new email-based identity from day 1
+	// land directly on the right shape; legacy installs (AUTHORIZED_USER
+	// without OWNER_EMAIL) get the historical `gh:<login>` placeholder and
+	// then the 006 step renames it.
+	const ownerEmail = process.env.OWNER_EMAIL;
 	const authorizedUser = process.env.AUTHORIZED_USER || 'legacy';
-	const ownerId = `gh:${authorizedUser}`;
+	const ownerId = ownerEmail || `gh:${authorizedUser}`;
+	const displayLogin = ownerEmail || authorizedUser;
 	const now = Date.now();
-	// Ensure users table exists before we INSERT into it.
 	execSql(
 		`CREATE TABLE IF NOT EXISTS users (
 			id TEXT PRIMARY KEY,
@@ -185,17 +191,67 @@ function maybeAddOwnerIdToLinks() {
 		execIdempotentAlter(`ALTER TABLE links ADD COLUMN owner_id TEXT;`);
 		execSql(
 			`INSERT OR IGNORE INTO users (id, github_login, email, created_at, updated_at)
-			 VALUES ('${ownerId}', '${authorizedUser}', NULL, ${now}, ${now});`,
+			 VALUES ('${ownerId}', '${displayLogin}', ${ownerEmail ? `'${ownerEmail}'` : 'NULL'}, ${now}, ${now});`,
 		);
 		execSql(`UPDATE links SET owner_id = '${ownerId}' WHERE owner_id IS NULL;`);
 	} else {
 		// Still backfill any null rows in case a previous partial run left them.
 		execSql(
 			`INSERT OR IGNORE INTO users (id, github_login, email, created_at, updated_at)
-			 VALUES ('${ownerId}', '${authorizedUser}', NULL, ${now}, ${now});`,
+			 VALUES ('${ownerId}', '${displayLogin}', ${ownerEmail ? `'${ownerEmail}'` : 'NULL'}, ${now}, ${now});`,
 		);
 		execSql(`UPDATE links SET owner_id = '${ownerId}' WHERE owner_id IS NULL;`);
 		console.log('  · links.owner_id already present (backfill verified)');
+	}
+}
+
+/**
+ * B4b (Sprint 2b): rename owner_id from the legacy `gh:<localpart>` form
+ * to the post-Access email-based identity. See 006_owner_id_email.sql for
+ * the full design rationale.
+ *
+ * Idempotent: skips with a log line if OWNER_EMAIL isn't set OR if the
+ * old row doesn't exist (already migrated / fresh install).
+ *
+ * Safe edge cases:
+ *   - Target row already exists (partial prior migration): point links
+ *     at the new row and delete the old user row instead of UPDATE on PK.
+ *   - OLD_OWNER_ID env var overrides the default `gh:<localpart>` guess
+ *     so existing prod data with a different legacy shape (e.g.
+ *     `gh:mackhaymond` while OWNER_EMAIL=mack.haymond@icloud.com) can
+ *     still be renamed without us hardcoding assumptions.
+ */
+function maybeRenameOwnerIdToEmail() {
+	const email = process.env.OWNER_EMAIL;
+	if (!email) {
+		console.log('  · OWNER_EMAIL not set, skipping owner_id rename (set it to migrate legacy gh:* rows)');
+		return;
+	}
+	if (!email.includes('@')) {
+		throw new Error(`OWNER_EMAIL must be a valid email, got: ${email}`);
+	}
+	const expectedLocalPart = email.split('@')[0];
+	const oldId = process.env.OLD_OWNER_ID || `gh:${expectedLocalPart}`;
+
+	const result = execSqlJson(`SELECT id FROM users WHERE id = '${oldId}';`);
+	const oldRows = (result?.[0]?.results) || [];
+	if (oldRows.length === 0) {
+		console.log(`  · no rows with owner_id ${oldId} to rename (already migrated or fresh install)`);
+		return;
+	}
+
+	const targetResult = execSqlJson(`SELECT id FROM users WHERE id = '${email}';`);
+	const targetExists = ((targetResult?.[0]?.results) || []).length > 0;
+	const now = Date.now();
+
+	if (targetExists) {
+		console.log(`  + rename owner_id ${oldId} -> ${email} (target row exists; merging)`);
+		execSql(`UPDATE links SET owner_id = '${email}' WHERE owner_id = '${oldId}';`);
+		execSql(`DELETE FROM users WHERE id = '${oldId}';`);
+	} else {
+		console.log(`  + rename owner_id ${oldId} -> ${email}`);
+		execSql(`UPDATE users SET id = '${email}', email = '${email}', updated_at = ${now} WHERE id = '${oldId}';`);
+		execSql(`UPDATE links SET owner_id = '${email}' WHERE owner_id = '${oldId}';`);
 	}
 }
 
@@ -214,6 +270,7 @@ const PROGRAMMATIC_STEPS = {
 	'002_counters_expiry.sql': maybeAddExpiresAtToCounters,
 	'003_owner_id.sql': maybeAddOwnerIdToLinks,
 	'005_unique_visitors.sql': maybeAddUniqueClicks,
+	'006_owner_id_email.sql': maybeRenameOwnerIdToEmail,
 };
 
 function main() {

--- a/worker/src/auth.js
+++ b/worker/src/auth.js
@@ -1,4 +1,4 @@
-import { getConfig, getMockUser, isDevBypassEligible } from './config.js';
+import { getMockUser, isDevBypassEligible } from './config.js';
 import { verifyAccessJwt } from './access.js';
 import { withCors } from './cors.js';
 import { logger } from './logger.js';
@@ -36,15 +36,19 @@ function isLocalHostRequest(request) {
 /**
  * Resolve the user behind a request, or null if unauthenticated.
  *
- * Identity shape (preserved across the OAuth -> Access migration so
- * downstream callers like getOwnerId / routesLinks don't break):
+ * Identity shape:
  *   { login, email, name, id, avatar_url }
  *
- *  - `login` is derived from the email local-part (same as the GitHub
- *    `login` field for users whose GitHub username matches their primary
- *    email, which is the case for the single authorized user).
- *  - `id` is the Access subject claim (`sub`), prefixed-stable across
- *    Access sessions.
+ * B4b (Sprint 2b): `login` is now the FULL email (e.g.
+ * "mack.haymond@icloud.com"), not the local-part. Reasons:
+ *   - The previous local-part-only derivation collided across domains
+ *     ("mack@a.com" and "mack@b.com" both yielded login="mack")
+ *   - It made plus-addressing ugly ("mack+test@icloud.com" → login="mack+test")
+ *   - downstream owner_id derivation in users.js becomes simpler (the
+ *     gh:* prefix is gone; owner_id IS the email)
+ *
+ * `id` is the Access subject claim (`sub`), prefixed-stable across
+ * Access sessions.
  */
 export async function authenticateRequest(env, request) {
 	if (isDevBypassEligible(env) && isLocalHostRequest(request)) {
@@ -57,7 +61,7 @@ export async function authenticateRequest(env, request) {
 	try {
 		const payload = await verifyAccessJwt(token, env.TEAM_DOMAIN, env.POLICY_AUD);
 		const email = String(payload.email || '');
-		const login = email.includes('@') ? email.split('@')[0] : (payload.sub || 'unknown');
+		const login = email || payload.sub || 'unknown';
 		return {
 			login,
 			email,
@@ -73,27 +77,28 @@ export async function authenticateRequest(env, request) {
 
 /**
  * Auth-gate a request and return the resolved user, or return a Response
- * to short-circuit. Contract preserved verbatim from pre-Sprint-2a so
- * existing callsites in routerApi.js work unchanged:
+ * to short-circuit. Contract preserved verbatim:
  *
  *   const result = await requireAuth(env, request);
  *   if (result instanceof Response) return result;
  *   // ...use result as the user object...
  *
- * The AUTHORIZED_USER env var check is kept as belt-and-suspenders: Access
- * already restricts to allowed identities at the edge via its Allow policy,
- * but if Access were ever misconfigured (e.g. policy disabled while the
- * app stays Required) we still reject unknown logins here.
+ * B4a (Sprint 2b): the prior AUTHORIZED_USER belt-and-suspenders check
+ * is GONE. Authorization is enforced upstream by Cloudflare Access's
+ * Allow policy at the edge — that's the source of truth for "who can
+ * access this app". The duplicated Worker-side check already bit us
+ * once (Sprint 2a postmortem: the Worker compared 'mack.haymond' to
+ * 'mackhaymond' and 403'd production for an hour). Don't reintroduce
+ * the double-source-of-truth pattern; trust the edge policy.
+ *
+ * If Access is ever misconfigured (Allow policy disabled while app
+ * stays Required), the failure mode is "anyone in the org reaches
+ * the worker", not "no one can". Detect via SECURITY.md path-coverage
+ * audits, not in-band Worker logic.
  */
 export async function requireAuth(env, request) {
 	const user = await authenticateRequest(env, request);
 	if (!user) return withCors(env, new Response('Unauthorized', { status: 401 }), request);
-
-	const { authorizedUser } = getConfig(env);
-	const devBypass = isDevBypassEligible(env);
-	if (!devBypass && authorizedUser && user.login !== authorizedUser) {
-		return withCors(env, new Response('Forbidden: Access denied', { status: 403 }), request);
-	}
 	return user;
 }
 

--- a/worker/src/config.js
+++ b/worker/src/config.js
@@ -23,13 +23,17 @@ export function isDevBypassEligible(env = {}) {
 
 /**
  * Reads request-time config from env vars. Returns only fields still in
- * use after Sprint 2a (A2). Removed:
+ * use after Sprint 2a (A2) + Sprint 2b. Removed:
  *   - githubClientId / githubClientSecret (OAuth gone)
  *   - jwtSecret (no Worker-issued JWTs anymore)
  *   - sessionCookieName / sessionMaxAgeSeconds (no Worker session cookie)
  *   - allowedRedirectUris (no OAuth redirect_uri)
  *   - authDisabled (only the old routesOAuth.js read this; auth.js uses
  *     isDevBypassEligible(env) directly)
+ *   - authorizedUser (B4a, Sprint 2b: belt-and-suspenders check removed
+ *     from requireAuth; authorization is now solely Cloudflare Access's job)
+ *   - rateLimits (B1, Sprint 2b: native rate-limit binding owns its limits
+ *     in wrangler.jsonc; in-app config no longer needed)
  *
  * `allowInsecureCookies` is preserved because routes/password.js still
  * sets a per-shortcode password-session cookie (that feature is
@@ -39,7 +43,6 @@ export function getConfig(env = {}) {
 	const allowInsecureCookies = String(env.SESSION_ALLOW_INSECURE_COOKIES || '').toLowerCase() === 'true' || isDevBypassEligible(env);
 
 	return {
-		authorizedUser: env.AUTHORIZED_USER,
 		allowInsecureCookies,
 		authDisabledUserLogin: env.AUTH_DISABLED_USER_LOGIN,
 		authDisabledUserName: env.AUTH_DISABLED_USER_NAME,
@@ -49,16 +52,6 @@ export function getConfig(env = {}) {
 			default: 10000,
 			jsonParse: 2000,
 			github: 8000,
-		},
-		rateLimits: {
-			createPerHour: 50,
-			updatePerHour: 200,
-			deletePerHour: 200,
-			bulkCreatePerHour: 50,
-			bulkDeletePerHour: 50,
-			windowMs: 60 * 60 * 1000,
-			// Password verify attempts per (shortcode + IP) per minute
-			passwordVerifyPerMinute: 10,
 		},
 	};
 }

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -1,7 +1,7 @@
 import { logger } from './logger.js';
 import { handleRequest } from './routes.js';
 import { withCors } from './cors.js';
-import { json, cleanupExpiredCounters, purgeExpiredLinks } from './utils.js';
+import { json, cleanupExpiredPasswordSessions, purgeExpiredLinks } from './utils.js';
 import { withSecurityHeaders } from './securityHeaders.js';
 import { purgeOldAnalytics } from './analytics.js';
 
@@ -89,10 +89,11 @@ export default {
 	 * 03:00 UTC). All cleanup runs are consolidated here:
 	 *   - H18 purgeOldAnalytics: drop analytics_day/_agg rows older than
 	 *     ANALYTICS_RETENTION_DAYS (default 365).
-	 *   - H7  cleanupExpiredCounters: drop counters rows whose `expires_at`
-	 *     is in the past (rate-limit buckets, password sessions, etc.).
-	 *     S2 removed the opportunistic 60s-gated hot-path call - this cron
-	 *     run is now the sole owner of counter cleanup.
+	 *   - B1  cleanupExpiredPasswordSessions: drop counters rows whose
+	 *     `expires_at` is past. Post-Sprint-2b, the counters table is no
+	 *     longer used for rate limiting (native binding owns that), so
+	 *     these rows are exclusively password-session tokens written by
+	 *     routes/password.js.
 	 *   - S2  purgeExpiredLinks: hard-delete links whose `expires_at` is
 	 *     past, mirroring the analytics policy (vs. the user-driven
 	 *     `archived` flag, which is preserved).
@@ -106,13 +107,13 @@ export default {
 		const purgeAnalytics = purgeOldAnalytics(env, retentionDays).catch((err) =>
 			logger.error('cron_purge_analytics_failed', { error: err?.message }),
 		);
-		const cleanupCounters = cleanupExpiredCounters(env).catch((err) =>
-			logger.error('cron_cleanup_counters_failed', { error: err?.message }),
+		const cleanupSessions = cleanupExpiredPasswordSessions(env).catch((err) =>
+			logger.error('cron_cleanup_password_sessions_failed', { error: err?.message }),
 		);
 		const purgeLinks = purgeExpiredLinks(env).catch((err) =>
 			logger.error('cron_purge_expired_links_failed', { error: err?.message }),
 		);
-		ctx.waitUntil(Promise.all([purgeAnalytics, cleanupCounters, purgeLinks]));
+		ctx.waitUntil(Promise.all([purgeAnalytics, cleanupSessions, purgeLinks]));
 	},
 };
 

--- a/worker/src/migrations/006_owner_id_email.sql
+++ b/worker/src/migrations/006_owner_id_email.sql
@@ -1,0 +1,23 @@
+-- B4b (Sprint 2b): rename owner_id from the legacy `gh:<localpart>` form
+-- to the post-Access email-based identity. The actual rename is done by
+-- the programmatic step `maybeRenameOwnerIdToEmail` in scripts/migrate.mjs
+-- because:
+--   1. It needs to read env vars (OWNER_EMAIL, optional OLD_OWNER_ID) to
+--      know what to rename — pure SQL can't do that
+--   2. It needs to be idempotent across the gh:* → email transition AND
+--      handle the case where the target row already exists (partial prior
+--      migration), which requires control flow not expressible in one SQL file
+--   3. It must touch both `users.id` (PK) and `links.owner_id` in a
+--      coordinated way that depends on whether the target row exists
+--
+-- Usage:
+--   OWNER_EMAIL=you@example.com npm run db:apply:prod
+--     -> renames owner_id 'gh:you' to 'you@example.com'
+--
+--   OLD_OWNER_ID=gh:legacyname OWNER_EMAIL=you@example.com npm run db:apply:prod
+--     -> renames owner_id from the explicit OLD_OWNER_ID to OWNER_EMAIL
+--     (use this when the gh: local-part doesn't match the email local-part,
+--      e.g. existing data is 'gh:mackhaymond' but email is mack.haymond@icloud.com)
+--
+-- Without OWNER_EMAIL the migration logs a skip and exits successfully —
+-- fresh installs with email-based identity from day 1 don't need it.

--- a/worker/src/migrations/006_owner_id_email.sql
+++ b/worker/src/migrations/006_owner_id_email.sql
@@ -19,5 +19,10 @@
 --     (use this when the gh: local-part doesn't match the email local-part,
 --      e.g. existing data is 'gh:mackhaymond' but email is mack.haymond@icloud.com)
 --
--- Without OWNER_EMAIL the migration logs a skip and exits successfully —
--- fresh installs with email-based identity from day 1 don't need it.
+--   OLD_OWNER_ID=gh:ai-dev NEW_OWNER_ID=ai-dev npm run db:apply:local
+--     -> raw rename, no email validation. Use for synthetic identities
+--     (local dev's mock 'ai-dev' user, test fixtures, non-email schemes).
+--
+-- Without any of these env vars the migration logs a skip and exits
+-- successfully -- fresh installs with email-based identity from day 1
+-- don't need it.

--- a/worker/src/rateLimit.js
+++ b/worker/src/rateLimit.js
@@ -1,0 +1,82 @@
+// B1: Wrapper around Cloudflare's native Rate-Limit binding.
+//
+// The binding (configured in wrangler.jsonc under `ratelimits`) exposes a
+// `.limit({ key })` method that returns `{ success: boolean }` synchronously
+// against a per-Cloudflare-location counter. Limits are sub-millisecond and
+// free; see SECURITY.md for the per-PoP / eventually-consistent caveat.
+//
+// Two design goals for this wrapper:
+//   1. Fail-OPEN if the binding is missing or throws. Rate limiting is a
+//      defense-in-depth layer, not a correctness guarantee — if the binding
+//      isn't wired (e.g. local vitest where miniflare doesn't simulate it,
+//      or a future env that hasn't been migrated yet), prefer letting the
+//      request through over hard-erroring. Logged so the misconfiguration
+//      is observable.
+//   2. Match the prior `isRateLimitedPersistent` return-shape semantics
+//      (boolean-y "should I return 429?") so call sites change minimally.
+//      The wrapper returns `{ allowed: boolean }`; callers check `!allowed`
+//      and build their own 429 response (because each caller wants a
+//      slightly different shape — text vs JSON).
+//
+// The companion helper `rateLimitResponse` constructs the 429 in a
+// CORS-wrapped, optionally-JSON form so callers don't repeat boilerplate.
+
+import { withCors } from './cors.js';
+import { logger } from './logger.js';
+
+/**
+ * Check a rate-limit binding for a given key.
+ *
+ * Fails open: if `binding` is missing/null or its `.limit()` throws, returns
+ * `{ allowed: true, fallback: true }` and logs a warning. Callers MUST treat
+ * a missing binding as "not rate limited" rather than crashing the request.
+ *
+ * @param {{ limit: (input: { key: string }) => Promise<{ success: boolean }> } | undefined} binding
+ *   The rate-limit binding (e.g. `env.RL_LINKS_CREATE`). Pass `undefined` to
+ *   exercise the fail-open path explicitly (useful in tests).
+ * @param {string} key - Bucket key. Use a stable per-user/per-resource string.
+ * @returns {Promise<{ allowed: boolean, fallback?: boolean, error?: string }>}
+ */
+export async function checkRateLimit(binding, key) {
+	if (!binding || typeof binding.limit !== 'function') {
+		// No binding wired up. This is expected in local vitest runs (miniflare
+		// doesn't currently expose the ratelimit binding). Don't log every
+		// call — that would drown out real signal in dev. The lack of a
+		// binding is structurally visible in wrangler.jsonc anyway.
+		return { allowed: true, fallback: true };
+	}
+	try {
+		const result = await binding.limit({ key });
+		return { allowed: !!result?.success };
+	} catch (err) {
+		logger.warn('rate_limit_binding_error', { key, error: err?.message });
+		return { allowed: true, fallback: true, error: err?.message };
+	}
+}
+
+/**
+ * Build a 429 response. Mirrors the prior in-route boilerplate so callers
+ * can swap a single line. Defaults to a plain-text body to match the
+ * legacy `new Response('Rate limit exceeded', { status: 429 })`; pass
+ * `json: true` to emit a JSON envelope `{ error: 'Rate limit exceeded' }`.
+ *
+ * @param {object} env - Worker env (for CORS allow-list)
+ * @param {Request} request - Incoming request (for CORS Origin echo)
+ * @param {object} [options]
+ * @param {boolean} [options.json] - Emit JSON body instead of plain text
+ * @param {string} [options.message] - Override the human message
+ * @returns {Response}
+ */
+export function rateLimitResponse(env, request, { json = false, message = 'Rate limit exceeded' } = {}) {
+	if (json) {
+		return withCors(
+			env,
+			new Response(JSON.stringify({ error: message }), {
+				status: 429,
+				headers: { 'Content-Type': 'application/json' },
+			}),
+			request,
+		);
+	}
+	return withCors(env, new Response(message, { status: 429 }), request);
+}

--- a/worker/src/routes.js
+++ b/worker/src/routes.js
@@ -3,6 +3,7 @@ import { handleRedirect } from './routes/redirect.js';
 import { handleAPI } from './routes/routerApi.js';
 import { handleAdmin } from './routes/admin.js';
 import { authenticateRequest } from './auth.js';
+import { logger } from './logger.js';
 
 export async function handleRequest(request, env, requestLogger, ctx) {
 	const url = new URL(request.url);
@@ -12,7 +13,7 @@ export async function handleRequest(request, env, requestLogger, ctx) {
 	}
 
 	if (url.pathname.startsWith('/api/')) {
-		return await handleAPI(request, env, requestLogger);
+		return await handleAPIWithSession(request, env, requestLogger);
 	}
 
 	// Handle admin panel routes
@@ -41,6 +42,60 @@ export async function handleRequest(request, env, requestLogger, ctx) {
 	const redirectResponse = await handleRedirect(request, env, requestLogger, ctx);
 	if (redirectResponse) return redirectResponse;
 	return withCors(env, new Response(renderHomeHtml(), { headers: { 'Content-Type': 'text/html; charset=utf-8' } }), request);
+}
+
+/**
+ * B2 (Sprint 2b): wrap /api/* requests in a D1 Sessions API session so that
+ * read replicas serve sequentially-consistent results. The contract:
+ *
+ *   1. Read the `x-d1-bookmark` request header (admin client passes the
+ *      bookmark from its prior response, if any).
+ *   2. Create a session via `env.DB.withSession(bookmark)`. The bookmark
+ *      sentinel `'first-unconstrained'` lets the first read hit any
+ *      replica — appropriate for first-load when no prior writes exist.
+ *   3. Hand handlers an env whose `.DB` is the session, not the raw
+ *      D1Database. This is API-compatible (`session.prepare/.batch/.first`
+ *      match D1Database) so existing db.js helpers don't change.
+ *   4. After the handler returns, attach `x-d1-bookmark` to the response
+ *      so the client can pass it back next time and keep read-your-writes
+ *      consistency across requests.
+ *
+ * Scope: API only. Hot-path (redirect.js, analytics writes) intentionally
+ * stays on raw `env.DB` because those paths are already eventually
+ * consistent by design and adding session bookkeeping would just add
+ * pointless latency.
+ *
+ * Works fine even when read replication is OFF (the dashboard toggle
+ * hasn't been flipped yet): `withSession` returns a session that always
+ * targets the primary, and `getBookmark()` returns the primary's bookmark.
+ * Code is identical either way — enabling replication is purely a runtime
+ * dashboard switch.
+ *
+ * Failure modes:
+ *   - If `env.DB` is missing (tests without DB binding), fall back to the
+ *     raw env so handlers can still return their own errors.
+ *   - If `getBookmark()` throws (no queries executed in the session),
+ *     silently skip the response header.
+ */
+async function handleAPIWithSession(request, env, requestLogger) {
+	if (!env?.DB || typeof env.DB.withSession !== 'function') {
+		return await handleAPI(request, env, requestLogger);
+	}
+	const bookmark = request.headers.get('x-d1-bookmark') || 'first-unconstrained';
+	const session = env.DB.withSession(bookmark);
+	const sessionEnv = { ...env, DB: session };
+	const response = await handleAPI(request, sessionEnv, requestLogger);
+	try {
+		const bm = session.getBookmark();
+		if (bm) {
+			const cloned = new Response(response.body, response);
+			cloned.headers.set('x-d1-bookmark', bm);
+			return cloned;
+		}
+	} catch (err) {
+		logger.warn('d1_session_bookmark_failed', { error: err?.message });
+	}
+	return response;
 }
 
 function renderHomeHtml() {

--- a/worker/src/routes.js
+++ b/worker/src/routes.js
@@ -4,6 +4,7 @@ import { handleAPI } from './routes/routerApi.js';
 import { handleAdmin } from './routes/admin.js';
 import { authenticateRequest } from './auth.js';
 import { logger } from './logger.js';
+import { generateCspNonce, htmlCspWithNonce } from './securityHeaders.js';
 
 export async function handleRequest(request, env, requestLogger, ctx) {
 	const url = new URL(request.url);
@@ -41,7 +42,18 @@ export async function handleRequest(request, env, requestLogger, ctx) {
 
 	const redirectResponse = await handleRedirect(request, env, requestLogger, ctx);
 	if (redirectResponse) return redirectResponse;
-	return withCors(env, new Response(renderHomeHtml(), { headers: { 'Content-Type': 'text/html; charset=utf-8' } }), request);
+	// B3 (Sprint 2b): nonce-based CSP for the marketing homepage.
+	const nonce = generateCspNonce();
+	return withCors(
+		env,
+		new Response(renderHomeHtml(nonce), {
+			headers: {
+				'Content-Type': 'text/html; charset=utf-8',
+				'Content-Security-Policy': htmlCspWithNonce(nonce),
+			},
+		}),
+		request,
+	);
 }
 
 /**
@@ -98,14 +110,14 @@ async function handleAPIWithSession(request, env, requestLogger) {
 	return response;
 }
 
-function renderHomeHtml() {
+function renderHomeHtml(nonce) {
 	return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>link.mackhaymond.co • Fast personal short links</title>
-  <style>
+  <style nonce="${nonce}">
     :root{--bg:#0b1220;--muted:#9aa4b2;--text:#eef2f7;--ring:rgba(96,165,250,.25)}
     *{box-sizing:border-box}
     body{margin:0;background:

--- a/worker/src/routes/password.js
+++ b/worker/src/routes/password.js
@@ -218,9 +218,15 @@ export async function verifyPasswordSession(env, shortcode, sessionToken) {
 }
 
 /**
- * Render password prompt page
+ * Render the password prompt page.
+ *
+ * B3 (Sprint 2b): `nonce` is REQUIRED. The inline `<style>` and `<script>`
+ * blocks each get `nonce="${nonce}"` so the nonce-based CSP set by the
+ * caller (via `htmlCspWithNonce(nonce)`) accepts them. Callers MUST pass
+ * the same nonce to both this function AND `htmlCspWithNonce` on the
+ * response — mismatched nonces yield blank pages in the browser.
  */
-export function renderPasswordPrompt(shortcode, error = null) {
+export function renderPasswordPrompt(shortcode, error, nonce) {
 	const errorHtml = error ? `<div class="error">${escapeHtml(error)}</div>` : '';
 
 	return `<!DOCTYPE html>
@@ -229,7 +235,7 @@ export function renderPasswordPrompt(shortcode, error = null) {
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Password Required • link.mackhaymond.co</title>
-  <style>
+  <style nonce="${nonce}">
     :root{--bg:#0b1220;--panel:rgba(17,24,39,.85);--muted:#9aa4b2;--text:#eef2f7;--accent:#2563eb;--accent-2:#60a5fa;--ring:rgba(96,165,250,.25);--error:#ef4444}
     *{box-sizing:border-box}
     body{margin:0;background:
@@ -280,7 +286,7 @@ export function renderPasswordPrompt(shortcode, error = null) {
     </div>
   </div>
 
-  <script>
+  <script nonce="${nonce}">
     document.getElementById('passwordForm').addEventListener('submit', async (e) => {
       e.preventDefault();
 

--- a/worker/src/routes/password.js
+++ b/worker/src/routes/password.js
@@ -2,7 +2,8 @@ import { withCors } from '../cors.js';
 import { verifyPasswordHash, generateSessionToken } from '../password.js';
 import { dbGet, dbRun } from '../db.js';
 import { getConfig } from '../config.js';
-import { isRateLimitedPersistent } from '../utils.js';
+import { getClientIP } from '../utils.js';
+import { checkRateLimit, rateLimitResponse } from '../rateLimit.js';
 import { logger } from '../logger.js';
 
 const PASSWORD_SESSION_TTL_SECONDS = 3600;
@@ -68,22 +69,15 @@ export async function handlePasswordVerification(request, env) {
 			);
 		}
 
-		// H5: rate-limit password attempts per (shortcode + IP) per minute.
-		const { rateLimits } = getConfig(env);
-		const limited = await isRateLimitedPersistent(env, request, {
-			key: `password:${shortcode}`,
-			limit: Number(rateLimits.passwordVerifyPerMinute || 10),
-			windowMs: 60 * 1000,
-		});
-		if (limited) {
-			return withCors(
-				env,
-				new Response(JSON.stringify({ error: 'Too many attempts. Please wait a minute and try again.' }), {
-					status: 429,
-					headers: { 'Content-Type': 'application/json' },
-				}),
-				request,
-			);
+		// H5: rate-limit password attempts per (shortcode + IP). Key combines
+		// both so brute-forcing one shortcode from one IP is bounded, but a
+		// shared-IP NAT can still attempt different shortcodes.
+		const rl = await checkRateLimit(env.RL_PASSWORD_VERIFY, `${shortcode}:${getClientIP(request)}`);
+		if (!rl.allowed) {
+			return rateLimitResponse(env, request, {
+				json: true,
+				message: 'Too many attempts. Please wait a minute and try again.',
+			});
 		}
 
 		// Get link data including password hash

--- a/worker/src/routes/redirect.js
+++ b/worker/src/routes/redirect.js
@@ -4,6 +4,7 @@ import { getAnalyticsStatements, computeVisitorFingerprint, markVisitorIfNew } f
 import { dbGet } from '../db.js';
 import { getClientIP } from '../utils.js';
 import { verifyPasswordSession, renderPasswordPrompt, readPasswordSessionCookie } from './password.js';
+import { generateCspNonce, htmlCspWithNonce } from '../securityHeaders.js';
 
 export async function handleRedirect(request, env, requestLogger = logger, ctx) {
 	const url = new URL(request.url);
@@ -52,17 +53,11 @@ export async function handleRedirect(request, env, requestLogger = logger, ctx) 
 	if (link.passwordEnabled && link.passwordHash) {
 		const sessionToken = readPasswordSessionCookie(request, shortcode);
 		if (!sessionToken) {
-			return new Response(renderPasswordPrompt(shortcode), {
-				status: 401,
-				headers: { 'Content-Type': 'text/html; charset=utf-8' },
-			});
+			return passwordPromptResponse(shortcode);
 		}
 		const isValidSession = await verifyPasswordSession(env, shortcode, sessionToken);
 		if (!isValidSession) {
-			return new Response(renderPasswordPrompt(shortcode, 'Session expired. Please enter password again.'), {
-				status: 401,
-				headers: { 'Content-Type': 'text/html; charset=utf-8' },
-			});
+			return passwordPromptResponse(shortcode, 'Session expired. Please enter password again.');
 		}
 	}
 	// C9: filter bots, prefetch hints, and HEAD requests BEFORE building the
@@ -157,19 +152,49 @@ function detectPrefetch(request) {
 	return false;
 }
 
-function htmlError(env, request, status, title, subtitle) {
-	const html = renderErrorHtml({ status, title, subtitle });
-	return withCors(env, new Response(html, { status, headers: { 'Content-Type': 'text/html; charset=utf-8' } }), request);
+/**
+ * B3 (Sprint 2b): build the password-prompt response with a fresh per-request
+ * nonce and a matching nonce-based CSP. The inline `<style>` and `<script>`
+ * in renderPasswordPrompt carry `nonce="${nonce}"` and the CSP header
+ * accepts exactly that nonce; mismatched values would render the page blank.
+ */
+function passwordPromptResponse(shortcode, error = null) {
+	const nonce = generateCspNonce();
+	return new Response(renderPasswordPrompt(shortcode, error, nonce), {
+		status: 401,
+		headers: {
+			'Content-Type': 'text/html; charset=utf-8',
+			'Content-Security-Policy': htmlCspWithNonce(nonce),
+		},
+	});
 }
 
-function renderErrorHtml({ status, title, subtitle }) {
+function htmlError(env, request, status, title, subtitle) {
+	// B3 (Sprint 2b): generate per-request nonce so the error page's inline
+	// <style> survives the nonce-based CSP without 'unsafe-inline'.
+	const nonce = generateCspNonce();
+	const html = renderErrorHtml({ status, title, subtitle, nonce });
+	return withCors(
+		env,
+		new Response(html, {
+			status,
+			headers: {
+				'Content-Type': 'text/html; charset=utf-8',
+				'Content-Security-Policy': htmlCspWithNonce(nonce),
+			},
+		}),
+		request,
+	);
+}
+
+function renderErrorHtml({ status, title, subtitle, nonce }) {
 	return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>${escapeHtml(String(status))} • link.mackhaymond.co</title>
-  <style>
+  <style nonce="${nonce}">
     :root{--bg:#0b1220;--panel:rgba(17,24,39,.85);--muted:#9aa4b2;--text:#eef2f7;--accent:#2563eb;--accent-2:#60a5fa;--ring:rgba(96,165,250,.25)}
     *{box-sizing:border-box}
     body{margin:0;background:

--- a/worker/src/routes/routesLinks.js
+++ b/worker/src/routes/routesLinks.js
@@ -1,8 +1,8 @@
 import { withCors } from '../cors.js';
-import { sanitizeInput, isRateLimitedPersistent } from '../utils.js';
+import { sanitizeInput, getClientIP } from '../utils.js';
+import { checkRateLimit, rateLimitResponse } from '../rateLimit.js';
 import { validateShortcode, validateUrl, validateDescription, validateRedirectType, validateTags, validateISODate, validateActivationWindow } from '../validation.js';
 import { dbAll, dbGet, dbRun } from '../db.js';
-import { getConfig } from '../config.js';
 import { createPasswordHash, validatePasswordStrength } from '../password.js';
 
 // C13: explicit column list (never SELECT *, so password_hash can never leak)
@@ -58,16 +58,11 @@ function safeParseJsonArray(text) {
 
 export async function createLink(request, env, ownerId) {
 	try {
-		const { rateLimits } = getConfig(env);
-		if (
-			await isRateLimitedPersistent(env, request, {
-				key: 'create',
-				limit: Number(rateLimits.createPerHour || 50),
-				windowMs: Number(rateLimits.windowMs || 3600000),
-			})
-		) {
-			return withCors(env, new Response('Rate limit exceeded', { status: 429 }), request);
-		}
+		// B1: native rate-limit binding. Key includes ownerId so a single
+		// abusive user doesn't lock out other tenants (currently single-user
+		// but the multi-tenancy contract from C6 is preserved).
+		const rl = await checkRateLimit(env.RL_LINKS_CREATE, `${ownerId}:${getClientIP(request)}`);
+		if (!rl.allowed) return rateLimitResponse(env, request);
 		const body = await request.json();
 		let { shortcode, url, description, redirectType, tags, archived, activatesAt, expiresAt, password } = body;
 		shortcode = sanitizeInput(shortcode);
@@ -234,16 +229,8 @@ export async function updateLink(request, env, shortcode, ownerId) {
 			lastClicked: row.last_clicked || null,
 			passwordEnabled: !!row.password_enabled,
 		};
-		const { rateLimits } = getConfig(env);
-		if (
-			await isRateLimitedPersistent(env, request, {
-				key: 'update',
-				limit: Number(rateLimits.updatePerHour || 200),
-				windowMs: Number(rateLimits.windowMs || 3600000),
-			})
-		) {
-			return withCors(env, new Response('Rate limit exceeded', { status: 429 }), request);
-		}
+		const rl = await checkRateLimit(env.RL_LINKS_MUTATE, `${ownerId}:${getClientIP(request)}`);
+		if (!rl.allowed) return rateLimitResponse(env, request);
 		const updates = await request.json();
 		let { url, description, redirectType, tags, archived, activatesAt, expiresAt, password } = updates;
 		if (url !== undefined) url = sanitizeInput(url);
@@ -380,36 +367,16 @@ export async function deleteLink(env, shortcode, request, ownerId) {
 	// for not-yours so we don't leak existence.
 	const existing = await dbGet(env, `SELECT shortcode FROM links WHERE shortcode = ? AND owner_id = ?`, [shortcode, ownerId]);
 	if (!existing) return withCors(env, new Response('Link not found', { status: 404 }), request);
-	const { rateLimits } = getConfig(env);
-	if (
-		await isRateLimitedPersistent(env, request, {
-			key: 'delete',
-			limit: Number(rateLimits.deletePerHour || 200),
-			windowMs: Number(rateLimits.windowMs || 3600000),
-		})
-	) {
-		return withCors(env, new Response('Rate limit exceeded', { status: 429 }), request);
-	}
+	const rl = await checkRateLimit(env.RL_LINKS_MUTATE, `${ownerId}:${getClientIP(request)}`);
+	if (!rl.allowed) return rateLimitResponse(env, request);
 	await dbRun(env, `DELETE FROM links WHERE shortcode = ? AND owner_id = ?`, [shortcode, ownerId]);
 	return withCors(env, new Response(null, { status: 204 }), request);
 }
 
 export async function bulkDeleteLinks(request, env, ownerId) {
 	try {
-		const { rateLimits } = getConfig(env);
-		if (
-			await isRateLimitedPersistent(env, request, {
-				key: 'bulkDelete',
-				limit: Number(rateLimits.bulkDeletePerHour || 50),
-				windowMs: Number(rateLimits.windowMs || 3600000),
-			})
-		) {
-			return withCors(
-				env,
-				new Response(JSON.stringify({ error: 'Rate limit exceeded' }), { status: 429, headers: { 'Content-Type': 'application/json' } }),
-				request,
-			);
-		}
+		const rl = await checkRateLimit(env.RL_LINKS_BULK, `${ownerId}:${getClientIP(request)}`);
+		if (!rl.allowed) return rateLimitResponse(env, request, { json: true });
 		const { shortcodes } = await request.json();
 		if (!Array.isArray(shortcodes) || shortcodes.length === 0) {
 			return withCors(
@@ -515,20 +482,8 @@ export async function getLink(env, shortcode, request, ownerId) {
 
 export async function bulkCreateLinks(request, env, ownerId) {
 	try {
-		const { rateLimits } = getConfig(env);
-		if (
-			await isRateLimitedPersistent(env, request, {
-				key: 'bulkCreate',
-				limit: Number(rateLimits.bulkCreatePerHour || 50),
-				windowMs: Number(rateLimits.windowMs || 3600000),
-			})
-		) {
-			return withCors(
-				env,
-				new Response(JSON.stringify({ error: 'Rate limit exceeded' }), { status: 429, headers: { 'Content-Type': 'application/json' } }),
-				request,
-			);
-		}
+		const rl = await checkRateLimit(env.RL_LINKS_BULK, `${ownerId}:${getClientIP(request)}`);
+		if (!rl.allowed) return rateLimitResponse(env, request, { json: true });
 		const { items } = await request.json();
 		if (!Array.isArray(items) || items.length === 0) {
 			return withCors(

--- a/worker/src/securityHeaders.js
+++ b/worker/src/securityHeaders.js
@@ -17,11 +17,12 @@ function commonHeaders(isLocalHost) {
 }
 
 /**
- * CSP for HTML responses. Allows 'unsafe-inline' for script + style because
- * the password-prompt template inlines both. A future refactor could move
- * those to hashed/served assets and tighten script-src to 'self' + nonce.
+ * Default CSP for HTML responses we don't own (admin SPA served via
+ * Cloudflare Static Assets). Keeps 'unsafe-inline' for script + style
+ * because the Vite-built admin bundle inlines a small bootstrap and we
+ * can't reach into the SPA build to inject per-request nonces.
  */
-const CSP_HTML =
+const CSP_HTML_DEFAULT =
 	"default-src 'self'; " +
 	"img-src 'self' data: https:; " +
 	"style-src 'self' 'unsafe-inline'; " +
@@ -32,9 +33,52 @@ const CSP_HTML =
 	"form-action 'self'";
 
 /**
- * Wrap a Response with standard security headers.
- * For HTML responses (admin SPA, password prompt, redirect error pages) it
- * also adds Content-Security-Policy. Idempotent - re-applying is harmless.
+ * B3 (Sprint 2b): Generate a per-request CSP nonce. 128 bits of entropy
+ * from `crypto.randomUUID()` with hyphens stripped — sufficient for
+ * "unguessable by network attacker within the request lifetime" per the
+ * CSP3 nonce requirements.
+ */
+export function generateCspNonce() {
+	return crypto.randomUUID().replace(/-/g, '');
+}
+
+/**
+ * B3 (Sprint 2b): CSP for HTML responses where the Worker rendered the
+ * markup itself (password prompt, redirect error pages, marketing
+ * homepage). Drops `'unsafe-inline'` from style-src and script-src in
+ * favor of an explicit nonce on each inline `<style>` / `<script>` tag.
+ * Browsers will refuse to execute/apply any inline content WITHOUT a
+ * matching nonce, closing one XSS surface.
+ *
+ * The Worker generates a fresh nonce per request and threads it into
+ * the render function AND this header builder. The two values MUST
+ * match — that's what makes the nonce protection meaningful.
+ */
+export function htmlCspWithNonce(nonce) {
+	return (
+		"default-src 'self'; " +
+		"img-src 'self' data: https:; " +
+		`style-src 'self' 'nonce-${nonce}'; ` +
+		`script-src 'self' 'nonce-${nonce}'; ` +
+		"connect-src 'self'; " +
+		"frame-ancestors 'none'; " +
+		"base-uri 'self'; " +
+		"form-action 'self'"
+	);
+}
+
+/**
+ * Wrap a Response with standard security headers. For HTML responses
+ * (admin SPA, password prompt, redirect error pages) it also adds a
+ * default Content-Security-Policy IF the response doesn't already have
+ * one set.
+ *
+ * B3 (Sprint 2b): the "doesn't already have one" condition lets
+ * Worker-rendered HTML routes (password prompt, redirect errors,
+ * homepage) opt into a tightened nonce-based CSP by setting their own
+ * Content-Security-Policy header on the response. This function then
+ * leaves that custom CSP untouched and only adds the common headers
+ * (HSTS, nosniff, X-Frame-Options, etc.). Idempotent.
  */
 export function withSecurityHeaders(env, request, response) {
 	const url = new URL(request.url);
@@ -42,8 +86,8 @@ export function withSecurityHeaders(env, request, response) {
 	const headers = commonHeaders(isLocalHost);
 
 	const contentType = response.headers.get('Content-Type') || '';
-	if (contentType.includes('text/html')) {
-		headers['Content-Security-Policy'] = CSP_HTML;
+	if (contentType.includes('text/html') && !response.headers.get('Content-Security-Policy')) {
+		headers['Content-Security-Policy'] = CSP_HTML_DEFAULT;
 	}
 
 	const merged = new Response(response.body, response);
@@ -51,4 +95,4 @@ export function withSecurityHeaders(env, request, response) {
 	return merged;
 }
 
-export { CSP_HTML };
+export { CSP_HTML_DEFAULT };

--- a/worker/src/users.js
+++ b/worker/src/users.js
@@ -1,19 +1,32 @@
 import { dbRun } from './db.js';
 
 /**
- * Stable owner id derived from a user's GitHub login.
- * Format: 'gh:{login}'. Used as users.id and links.owner_id.
+ * Stable owner id for a user.
+ *
+ * B4b (Sprint 2b): owner_id is now just `user.login` (which itself is the
+ * full email after the auth.js refactor). Previously this prefixed `gh:`
+ * because the pre-Sprint-2a auth was GitHub OAuth — that prefix is now
+ * meaningless legacy (the migration 006 renames existing `gh:*` rows).
+ *
+ * The dev mock user (login='ai-dev', no '@') is still a valid identity;
+ * we don't enforce email shape here so test/dev paths keep working with
+ * synthetic identifiers.
  */
 export function ownerIdForUser(user) {
 	if (!user || typeof user.login !== 'string' || !user.login.trim()) {
 		throw new Error('user.login required to derive owner_id');
 	}
-	return `gh:${user.login.trim()}`;
+	return user.login.trim();
 }
 
 /**
- * Ensure a row exists in `users` for the given GitHub user.
+ * Ensure a row exists in `users` for the given user.
  * Called on every authenticated request path so first login lazily provisions.
+ *
+ * The `github_login` column predates the Access migration — it's kept as a
+ * display string (now stores whatever `user.login` happens to be: an email
+ * for real users, 'ai-dev' for the dev mock). Renaming the column is a
+ * future cleanup.
  */
 export async function ensureUser(env, user) {
 	const id = ownerIdForUser(user);

--- a/worker/src/utils.js
+++ b/worker/src/utils.js
@@ -1,7 +1,5 @@
 import { getConfig } from './config.js';
-import { dbAll } from './db.js';
 import { withCors } from './cors.js';
-import { logger } from './logger.js';
 
 /**
  * Enhanced input sanitization with better security
@@ -97,48 +95,6 @@ export async function retryWithBackoff(operation, { maxRetries = 3, baseDelay = 
 	}
 }
 
-// Simple in-memory caches (edge-local) with size limits to prevent memory leaks
-const MAX_CACHE_SIZE = 10000;
-
-class BoundedMap extends Map {
-	constructor(maxSize = MAX_CACHE_SIZE) {
-		super();
-		this.maxSize = maxSize;
-	}
-	
-	set(key, value) {
-		// Remove oldest entry if we're at capacity
-		if (this.size >= this.maxSize) {
-			const firstKey = this.keys().next().value;
-			this.delete(firstKey);
-		}
-		return super.set(key, value);
-	}
-}
-
-// Edge-local caches for token and rate limit data
-export const tokenCache = new BoundedMap();
-export const rateLimitCache = new BoundedMap();
-
-/**
- * In-memory rate limiter fallback (used when D1 is unavailable)
- * @param {string} key - Rate limit key (usually IP address)
- * @param {Object} options - Rate limit options
- * @param {number} options.limit - Request limit (default: 100)
- * @param {number} options.windowMs - Time window in milliseconds (default: 1 hour)
- * @returns {boolean} True if rate limited
- */
-export function isRateLimited(key, { limit = 100, windowMs = 3600000 } = {}) {
-	const now = Date.now();
-	const window = Math.floor(now / windowMs);
-	const cacheKey = `${key}:${window}`;
-	
-	const current = rateLimitCache.get(cacheKey) || 0;
-	rateLimitCache.set(cacheKey, current + 1);
-	
-	return current >= limit;
-}
-
 /**
  * Extract client IP address from request headers
  * @param {Request} request - Cloudflare Worker request
@@ -151,70 +107,20 @@ export function getClientIP(request) {
 }
 
 /**
- * Persistent D1-based rate limiter.
+ * B1 (Sprint 2b): drop expired counters-table rows. The counters table
+ * is no longer used for rate limiting (that moved to Cloudflare's native
+ * Rate-Limit binding — see rateLimit.js), but it still backs the
+ * per-shortcode password-session token store in routes/password.js. Each
+ * verified password attempt writes a `pwd_session:<shortcode>:<token>`
+ * row with an `expires_at` set 1 hour out; this sweep drops those after
+ * they expire. The SQL is generic ("any row whose expires_at is past")
+ * but in practice all such rows are password-session rows.
  *
- * S2: prior versions opportunistically fired `cleanupExpiredCounters` from
- * the hot path on a 60s interval (`maybeScheduleCleanup`) so that the
- * counters table didn't accumulate stale rows between cron runs. That
- * approach added a `ctx.waitUntil` tax to every rate-limited endpoint call
- * and risked floating promises in non-runtime contexts (tests, scripts).
- *
- * Counter cleanup is now exclusively the cron handler's job (see
- * `scheduled` in src/index.js). Callers that still pass `ctx` in opts are
- * fine - it's ignored, since this function no longer needs it.
+ * Safe to run on every cron tick — the partial index on
+ * `counters(expires_at) WHERE expires_at IS NOT NULL` keeps the scan
+ * bounded to active sessions.
  */
-export async function isRateLimitedPersistent(env, request, { key = 'default', limit = 100, windowMs = 3600000 } = {}) {
-	try {
-		const now = Date.now();
-		const bucket = Math.floor(now / windowMs);
-		const ip = getClientIP(request);
-		const name = `rate:${key}:${windowMs}:${bucket}:${ip}`;
-		const expiresAt = new Date(now + (windowMs * 2)).toISOString();
-		const rows = await dbAll(env,
-			`INSERT INTO counters (name, value, expires_at) VALUES (?, 1, ?)
-			 ON CONFLICT(name) DO UPDATE SET 
-			   value = counters.value + 1,
-			   expires_at = excluded.expires_at
-			 RETURNING value`,
-			[name, expiresAt]
-		);
-		const value = (rows && rows[0] && (rows[0].value ?? rows[0].VALUE)) || 0;
-		return Number(value) > Number(limit);
-	} catch (e) {
-		logger.warn('rate_limit_d1_fallback', { key, error: e?.message });
-		const ip = getClientIP(request);
-		return isRateLimited(ip, { limit, windowMs });
-	}
-}
-
-/**
- * Clean expired entries from in-memory caches
- * Should be called periodically to prevent memory buildup
- */
-export function cleanupCaches() {
-	const now = Date.now();
-	const oneHour = 3600000;
-	
-	// Clean up rate limit cache entries older than 2 windows
-	for (const [key] of rateLimitCache.entries()) {
-		const parts = key.split(':');
-		const window = parseInt(parts[parts.length - 1]);
-		const windowMs = parseInt(parts[parts.length - 3]) || oneHour;
-		if (isNaN(window) || (now - window * windowMs) > (2 * windowMs)) {
-			rateLimitCache.delete(key);
-		}
-	}
-	
-	// Token cache cleanup is handled by application logic
-	// but we can clear very old entries (older than 24 hours)
-	for (const [key, entry] of tokenCache.entries()) {
-		if (entry && entry.timestamp && (now - entry.timestamp) > (24 * oneHour)) {
-			tokenCache.delete(key);
-		}
-	}
-}
-
-export async function cleanupExpiredCounters(env) {
+export async function cleanupExpiredPasswordSessions(env) {
 	const now = new Date().toISOString();
 	const { dbRun } = await import('./db.js');
 	await dbRun(env, `DELETE FROM counters WHERE expires_at IS NOT NULL AND expires_at < ?`, [now]);

--- a/worker/test/auth.test.js
+++ b/worker/test/auth.test.js
@@ -4,7 +4,7 @@ import { _resetJwksCacheForTests } from '../src/access.js';
 import { isDevBypassEligible, getConfig, getMockUser } from '../src/config.js';
 import { TEAM_DOMAIN, POLICY_AUD, generateKeypair, buildJwks, mintJwt, stubJwksFetch } from './_helpers/access-fixture.js';
 
-const PROD_ENV = { TEAM_DOMAIN, POLICY_AUD, AUTHORIZED_USER: 'mackhaymond' };
+const PROD_ENV = { TEAM_DOMAIN, POLICY_AUD };
 const DEV_ENV = { ...PROD_ENV, AUTH_DISABLED: 'true', ENVIRONMENT: 'development' };
 
 function req(url, headers = {}) {
@@ -37,6 +37,14 @@ describe('config helpers (Sprint 2a)', () => {
 			expect(cfg.githubClientSecret).toBeUndefined();
 			expect(cfg.allowedRedirectUris).toBeUndefined();
 			expect(cfg.sessionCookieName).toBeUndefined();
+		});
+		it('B4a (Sprint 2b): no longer surfaces authorizedUser', () => {
+			const cfg = getConfig({ AUTHORIZED_USER: 'should-be-ignored' });
+			expect(cfg.authorizedUser).toBeUndefined();
+		});
+		it('B1 (Sprint 2b): no longer surfaces rateLimits (native binding owns it)', () => {
+			const cfg = getConfig({});
+			expect(cfg.rateLimits).toBeUndefined();
 		});
 	});
 
@@ -93,16 +101,34 @@ describe('authenticateRequest (Sprint 2a A1)', () => {
 		expect(user).toBeNull();
 	});
 
-	it('verifies a valid Cf-Access-Jwt-Assertion header and maps to identity', async () => {
-		const token = await mintJwt(keypair.privateKey, { email: 'mackhaymond@example.com', name: 'Mack H.', sub: 'access:42' });
+	it('B4b (Sprint 2b): login is the FULL email, not the local-part', async () => {
+		const token = await mintJwt(keypair.privateKey, { email: 'mack.haymond@icloud.com', name: 'Mack H.', sub: 'access:42' });
 		const user = await authenticateRequest(PROD_ENV, req('https://link.mackhaymond.co/api/links', {
 			'cf-access-jwt-assertion': token,
 		}));
 		expect(user).not.toBeNull();
-		expect(user.email).toBe('mackhaymond@example.com');
-		expect(user.login).toBe('mackhaymond');
+		expect(user.email).toBe('mack.haymond@icloud.com');
+		expect(user.login).toBe('mack.haymond@icloud.com');
 		expect(user.name).toBe('Mack H.');
 		expect(user.id).toBe('access:42');
+	});
+
+	it('B4b: plus-addressed emails round-trip without mangling', async () => {
+		const token = await mintJwt(keypair.privateKey, { email: 'mack+test@icloud.com' });
+		const user = await authenticateRequest(PROD_ENV, req('https://link.mackhaymond.co/api/links', {
+			'cf-access-jwt-assertion': token,
+		}));
+		expect(user.login).toBe('mack+test@icloud.com');
+	});
+
+	it('B4b: same local-part across different domains does NOT collide', async () => {
+		const a = await mintJwt(keypair.privateKey, { email: 'mack@example.com', sub: 'a' });
+		const b = await mintJwt(keypair.privateKey, { email: 'mack@other.com', sub: 'b' });
+		const uA = await authenticateRequest(PROD_ENV, req('https://link.mackhaymond.co/api/links', { 'cf-access-jwt-assertion': a }));
+		const uB = await authenticateRequest(PROD_ENV, req('https://link.mackhaymond.co/api/links', { 'cf-access-jwt-assertion': b }));
+		expect(uA.login).toBe('mack@example.com');
+		expect(uB.login).toBe('mack@other.com');
+		expect(uA.login).not.toBe(uB.login);
 	});
 
 	it('returns null on invalid JWT (verify throws)', async () => {
@@ -140,27 +166,24 @@ describe('requireAuth (contract preserved)', () => {
 	});
 
 	it('returns the user object when authenticated', async () => {
-		const token = await mintJwt(keypair.privateKey, { email: 'mackhaymond@example.com' });
+		const token = await mintJwt(keypair.privateKey, { email: 'mack.haymond@icloud.com' });
 		const result = await requireAuth(PROD_ENV, req('https://link.mackhaymond.co/api/links', {
 			'cf-access-jwt-assertion': token,
 		}));
 		expect(result).not.toBeInstanceOf(Response);
-		expect(result.login).toBe('mackhaymond');
+		expect(result.login).toBe('mack.haymond@icloud.com');
 	});
 
-	it('returns 403 when login does not match AUTHORIZED_USER (belt-and-suspenders)', async () => {
-		const token = await mintJwt(keypair.privateKey, { email: 'stranger@example.com' });
+	it('B4a (Sprint 2b): any authenticated identity is accepted - Access is the source of truth', async () => {
+		const token = await mintJwt(keypair.privateKey, { email: 'someone-else@example.com' });
 		const result = await requireAuth(PROD_ENV, req('https://link.mackhaymond.co/api/links', {
 			'cf-access-jwt-assertion': token,
 		}));
-		expect(result).toBeInstanceOf(Response);
-		expect(result.status).toBe(403);
+		expect(result).not.toBeInstanceOf(Response);
+		expect(result.login).toBe('someone-else@example.com');
 	});
 
-	it('dev bypass: AUTHORIZED_USER mismatch does NOT 403', async () => {
-		// dev mock user is 'ai-dev', AUTHORIZED_USER is 'mackhaymond' - in dev
-		// bypass the authorizedUser check is skipped (so local devs don't have
-		// to set AUTHORIZED_USER=ai-dev in .dev.vars).
+	it('dev bypass returns the mock user without auth', async () => {
 		const result = await requireAuth(DEV_ENV, req('http://localhost:8787/api/links'));
 		expect(result).not.toBeInstanceOf(Response);
 		expect(result.login).toBe('ai-dev');

--- a/worker/test/csp.test.js
+++ b/worker/test/csp.test.js
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { env } from 'cloudflare:test';
+import { handleRequest } from '../src/routes.js';
+import { withSecurityHeaders, generateCspNonce, htmlCspWithNonce } from '../src/securityHeaders.js';
+import { dbRun } from '../src/db.js';
+import { renderPasswordPrompt } from '../src/routes/password.js';
+
+async function ensureSchema() {
+	await dbRun(
+		env,
+		`CREATE TABLE IF NOT EXISTS links (
+			shortcode TEXT PRIMARY KEY, owner_id TEXT, url TEXT NOT NULL,
+			description TEXT DEFAULT '', redirect_type INTEGER DEFAULT 301,
+			tags TEXT DEFAULT '[]', archived INTEGER DEFAULT 0,
+			activates_at TEXT, expires_at TEXT, password_hash TEXT,
+			password_enabled INTEGER DEFAULT 0,
+			created TEXT NOT NULL, updated TEXT NOT NULL,
+			clicks INTEGER DEFAULT 0, last_clicked TEXT
+		)`,
+	);
+	await dbRun(
+		env,
+		`CREATE TABLE IF NOT EXISTS counters (
+			name TEXT PRIMARY KEY, value INTEGER DEFAULT 0, expires_at TEXT
+		)`,
+	);
+}
+
+const fakeLogger = { info: () => {}, warn: () => {}, error: () => {} };
+
+describe('CSP nonce primitives (B3)', () => {
+	it('generateCspNonce returns a 32-char hex-ish string with no hyphens', () => {
+		const a = generateCspNonce();
+		const b = generateCspNonce();
+		expect(a).toMatch(/^[0-9a-f]{32}$/);
+		expect(b).toMatch(/^[0-9a-f]{32}$/);
+		expect(a).not.toBe(b);
+	});
+
+	it('htmlCspWithNonce embeds the nonce in style-src and script-src and drops unsafe-inline', () => {
+		const csp = htmlCspWithNonce('abc123');
+		expect(csp).toContain("style-src 'self' 'nonce-abc123'");
+		expect(csp).toContain("script-src 'self' 'nonce-abc123'");
+		expect(csp).not.toContain("'unsafe-inline'");
+		expect(csp).toContain("frame-ancestors 'none'");
+		expect(csp).toContain("base-uri 'self'");
+	});
+
+	it('withSecurityHeaders does NOT overwrite a Content-Security-Policy already on the response', async () => {
+		const customCsp = htmlCspWithNonce('test-nonce-9');
+		const original = new Response('<html></html>', {
+			headers: {
+				'Content-Type': 'text/html',
+				'Content-Security-Policy': customCsp,
+			},
+		});
+		const wrapped = withSecurityHeaders(env, new Request('http://localhost:8787/'), original);
+		expect(wrapped.headers.get('Content-Security-Policy')).toBe(customCsp);
+	});
+
+	it('withSecurityHeaders applies the default (unsafe-inline) CSP when none is set (admin SPA path)', async () => {
+		const original = new Response('<html></html>', { headers: { 'Content-Type': 'text/html' } });
+		const wrapped = withSecurityHeaders(env, new Request('http://localhost:8787/admin'), original);
+		const csp = wrapped.headers.get('Content-Security-Policy');
+		expect(csp).toContain("'unsafe-inline'");
+	});
+});
+
+describe('renderPasswordPrompt nonce injection (B3)', () => {
+	it('injects nonce into <style> and <script> tags', () => {
+		const html = renderPasswordPrompt('demo', null, 'PWD-NONCE-XYZ');
+		expect(html).toContain('<style nonce="PWD-NONCE-XYZ">');
+		expect(html).toContain('<script nonce="PWD-NONCE-XYZ">');
+		expect(html).not.toMatch(/<style>(?!\s*nonce)/);
+		expect(html).not.toMatch(/<script>(?!\s*nonce)/);
+	});
+
+	it('renders the optional error message when provided', () => {
+		const html = renderPasswordPrompt('demo', 'Bad password', 'N1');
+		expect(html).toContain('Bad password');
+	});
+});
+
+describe('Worker-rendered HTML responses set nonce-based CSP (B3)', () => {
+	beforeEach(async () => {
+		await ensureSchema();
+		await dbRun(env, `DELETE FROM links`);
+		await dbRun(env, `DELETE FROM counters`);
+	});
+
+	it('marketing homepage emits a nonce-based CSP matching the inline <style> nonce', async () => {
+		// Use a non-localhost URL so the dev-bypass auth flow (mock user → 302 /admin)
+		// doesn't intercept. We want the homepage HTML path here.
+		const response = await handleRequest(
+			new Request('https://link.mackhaymond.co/'),
+			env,
+			fakeLogger,
+			null,
+		);
+		expect(response.status).toBe(200);
+		const csp = response.headers.get('Content-Security-Policy');
+		expect(csp).toBeTruthy();
+		expect(csp).toMatch(/style-src 'self' 'nonce-[0-9a-f]{32}'/);
+		expect(csp).toMatch(/script-src 'self' 'nonce-[0-9a-f]{32}'/);
+		expect(csp).not.toContain("'unsafe-inline'");
+		const nonceFromCsp = csp.match(/'nonce-([0-9a-f]{32})'/)[1];
+		const html = await response.text();
+		expect(html).toContain(`<style nonce="${nonceFromCsp}">`);
+	});
+
+	it('404 error page (unknown shortcode) emits a nonce-based CSP matching the inline <style> nonce', async () => {
+		const response = await handleRequest(
+			new Request('http://localhost:8787/this-does-not-exist'),
+			env,
+			fakeLogger,
+			null,
+		);
+		expect(response.status).toBe(404);
+		const csp = response.headers.get('Content-Security-Policy');
+		expect(csp).toMatch(/style-src 'self' 'nonce-[0-9a-f]{32}'/);
+		expect(csp).not.toContain("'unsafe-inline'");
+		const nonceFromCsp = csp.match(/'nonce-([0-9a-f]{32})'/)[1];
+		const html = await response.text();
+		expect(html).toContain(`<style nonce="${nonceFromCsp}">`);
+	});
+
+	it('password prompt response (gated short link) emits a nonce-based CSP matching the inline tags', async () => {
+		// Seed a password-protected link with a salt:hash that we won't try to verify
+		// (we just want the path that returns the prompt, not the verifier path).
+		const now = new Date().toISOString();
+		await dbRun(
+			env,
+			`INSERT INTO links (shortcode, owner_id, url, password_hash, password_enabled, created, updated, clicks)
+			 VALUES (?, ?, ?, ?, 1, ?, ?, 0)`,
+			['gated', 'gh:owner', 'https://example.com', 'fakesalt:fakehash', now, now],
+		);
+		const response = await handleRequest(
+			new Request('http://localhost:8787/gated'),
+			env,
+			fakeLogger,
+			null,
+		);
+		expect(response.status).toBe(401);
+		const csp = response.headers.get('Content-Security-Policy');
+		expect(csp).toMatch(/style-src 'self' 'nonce-[0-9a-f]{32}'/);
+		expect(csp).toMatch(/script-src 'self' 'nonce-[0-9a-f]{32}'/);
+		expect(csp).not.toContain("'unsafe-inline'");
+		const nonceFromCsp = csp.match(/'nonce-([0-9a-f]{32})'/)[1];
+		const html = await response.text();
+		expect(html).toContain(`<style nonce="${nonceFromCsp}">`);
+		expect(html).toContain(`<script nonce="${nonceFromCsp}">`);
+	});
+
+	it('two successive requests get two distinct nonces (no nonce reuse)', async () => {
+		const r1 = await handleRequest(new Request('https://link.mackhaymond.co/'), env, fakeLogger, null);
+		const r2 = await handleRequest(new Request('https://link.mackhaymond.co/'), env, fakeLogger, null);
+		const n1 = r1.headers.get('Content-Security-Policy').match(/'nonce-([0-9a-f]{32})'/)[1];
+		const n2 = r2.headers.get('Content-Security-Policy').match(/'nonce-([0-9a-f]{32})'/)[1];
+		expect(n1).not.toBe(n2);
+	});
+});

--- a/worker/test/rateLimit.test.js
+++ b/worker/test/rateLimit.test.js
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from 'vitest';
+import { checkRateLimit, rateLimitResponse } from '../src/rateLimit.js';
+
+const env = { ALLOWED_ORIGINS: 'http://localhost:8787' };
+
+function fakeBinding(verdicts) {
+	const queue = Array.isArray(verdicts) ? [...verdicts] : [];
+	const limit = vi.fn(async () => ({ success: queue.length ? queue.shift() : true }));
+	return { limit };
+}
+
+describe('checkRateLimit (B1)', () => {
+	it('allows requests when binding returns success: true', async () => {
+		const binding = fakeBinding([true]);
+		const result = await checkRateLimit(binding, 'user-1');
+		expect(result.allowed).toBe(true);
+		expect(binding.limit).toHaveBeenCalledWith({ key: 'user-1' });
+	});
+
+	it('denies requests when binding returns success: false', async () => {
+		const binding = fakeBinding([false]);
+		const result = await checkRateLimit(binding, 'user-1');
+		expect(result.allowed).toBe(false);
+	});
+
+	it('isolates counters by key: two different keys do not share state', async () => {
+		const calls = [];
+		const binding = {
+			limit: vi.fn(async ({ key }) => {
+				calls.push(key);
+				return { success: true };
+			}),
+		};
+		await checkRateLimit(binding, 'user-a');
+		await checkRateLimit(binding, 'user-b');
+		expect(calls).toEqual(['user-a', 'user-b']);
+		expect(binding.limit).toHaveBeenCalledTimes(2);
+	});
+
+	it('fails OPEN when binding is undefined (missing in env)', async () => {
+		const result = await checkRateLimit(undefined, 'user-1');
+		expect(result.allowed).toBe(true);
+		expect(result.fallback).toBe(true);
+	});
+
+	it('fails OPEN when binding has no .limit method', async () => {
+		const result = await checkRateLimit({}, 'user-1');
+		expect(result.allowed).toBe(true);
+		expect(result.fallback).toBe(true);
+	});
+
+	it('fails OPEN when binding throws (defense-in-depth)', async () => {
+		const binding = {
+			limit: vi.fn(async () => {
+				throw new Error('upstream rate-limit infra unavailable');
+			}),
+		};
+		const result = await checkRateLimit(binding, 'user-1');
+		expect(result.allowed).toBe(true);
+		expect(result.fallback).toBe(true);
+		expect(result.error).toMatch(/upstream/);
+	});
+
+	it('repeated denials stay denied (binding owns the window)', async () => {
+		const binding = fakeBinding([false, false, false]);
+		expect((await checkRateLimit(binding, 'k')).allowed).toBe(false);
+		expect((await checkRateLimit(binding, 'k')).allowed).toBe(false);
+		expect((await checkRateLimit(binding, 'k')).allowed).toBe(false);
+	});
+});
+
+describe('rateLimitResponse (B1)', () => {
+	function req(url = 'http://localhost:8787/api/links') {
+		return new Request(url, { headers: { Origin: 'http://localhost:8787' } });
+	}
+
+	it('emits a 429 text/plain by default with the legacy message', async () => {
+		const res = rateLimitResponse(env, req());
+		expect(res.status).toBe(429);
+		expect(await res.text()).toBe('Rate limit exceeded');
+	});
+
+	it('emits a 429 JSON envelope when json: true (mirrors legacy bulk-op shape)', async () => {
+		const res = rateLimitResponse(env, req(), { json: true });
+		expect(res.status).toBe(429);
+		expect(res.headers.get('Content-Type')).toContain('application/json');
+		const body = await res.json();
+		expect(body.error).toBe('Rate limit exceeded');
+	});
+
+	it('honors a custom message (used by password-verify path)', async () => {
+		const res = rateLimitResponse(env, req(), {
+			json: true,
+			message: 'Too many attempts. Please wait a minute and try again.',
+		});
+		const body = await res.json();
+		expect(body.error).toMatch(/Too many attempts/);
+	});
+
+	it('echoes allow-listed Origin via CORS (matches the rest of the worker)', async () => {
+		const res = rateLimitResponse(env, req());
+		expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://localhost:8787');
+	});
+});

--- a/worker/test/sessions.test.js
+++ b/worker/test/sessions.test.js
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { env } from 'cloudflare:test';
+import { handleRequest } from '../src/routes.js';
+import { dbRun } from '../src/db.js';
+
+async function ensureSchema() {
+	await dbRun(
+		env,
+		`CREATE TABLE IF NOT EXISTS users (
+			id TEXT PRIMARY KEY,
+			github_login TEXT UNIQUE NOT NULL,
+			email TEXT,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL
+		)`,
+	);
+	await dbRun(
+		env,
+		`CREATE TABLE IF NOT EXISTS links (
+			shortcode TEXT PRIMARY KEY,
+			owner_id TEXT,
+			url TEXT NOT NULL,
+			description TEXT DEFAULT '',
+			redirect_type INTEGER DEFAULT 301,
+			tags TEXT DEFAULT '[]',
+			archived INTEGER DEFAULT 0,
+			activates_at TEXT,
+			expires_at TEXT,
+			password_hash TEXT,
+			password_enabled INTEGER DEFAULT 0,
+			created TEXT NOT NULL,
+			updated TEXT NOT NULL,
+			clicks INTEGER DEFAULT 0,
+			last_clicked TEXT
+		)`,
+	);
+}
+
+function req(url, init = {}) {
+	return new Request(url, init);
+}
+
+const fakeLogger = { info: () => {}, warn: () => {}, error: () => {} };
+
+describe('D1 Sessions API integration (B2)', () => {
+	beforeEach(async () => {
+		await ensureSchema();
+		await dbRun(env, `DELETE FROM links`);
+		await dbRun(env, `DELETE FROM users`);
+	});
+
+	it('attaches x-d1-bookmark header to /api/* responses (so the client can round-trip it)', async () => {
+		const response = await handleRequest(
+			req('http://localhost:8787/api/user'),
+			env,
+			fakeLogger,
+			null,
+		);
+		expect(response.status).toBe(200);
+		const bookmark = response.headers.get('x-d1-bookmark');
+		expect(typeof bookmark === 'string' || bookmark === null).toBe(true);
+	});
+
+	it('threads the request bookmark into env.DB.withSession()', async () => {
+		const calls = [];
+		const captureSessionDb = {
+			withSession: (bookmark) => {
+				calls.push(bookmark);
+				return {
+					prepare: (sql) => env.DB.prepare(sql),
+					batch: (stmts) => env.DB.batch(stmts),
+					getBookmark: () => 'bm-after-test',
+				};
+			},
+		};
+		const fakeEnv = { ...env, DB: captureSessionDb };
+		const response = await handleRequest(
+			req('http://localhost:8787/api/user', { headers: { 'x-d1-bookmark': 'caller-bm-42' } }),
+			fakeEnv,
+			fakeLogger,
+			null,
+		);
+		expect(calls).toEqual(['caller-bm-42']);
+		expect(response.headers.get('x-d1-bookmark')).toBe('bm-after-test');
+	});
+
+	it('defaults to first-unconstrained when no bookmark header is present', async () => {
+		const calls = [];
+		const captureSessionDb = {
+			withSession: (bookmark) => {
+				calls.push(bookmark);
+				return {
+					prepare: (sql) => env.DB.prepare(sql),
+					batch: (stmts) => env.DB.batch(stmts),
+					getBookmark: () => null,
+				};
+			},
+		};
+		const fakeEnv = { ...env, DB: captureSessionDb };
+		await handleRequest(req('http://localhost:8787/api/user'), fakeEnv, fakeLogger, null);
+		expect(calls).toEqual(['first-unconstrained']);
+	});
+
+	it('non-API paths skip session creation (hot path stays on raw env.DB)', async () => {
+		const calls = [];
+		const captureSessionDb = {
+			withSession: (bookmark) => {
+				calls.push(bookmark);
+				return {
+					prepare: (sql) => env.DB.prepare(sql),
+					batch: (stmts) => env.DB.batch(stmts),
+					getBookmark: () => null,
+				};
+			},
+		};
+		const fakeEnv = { ...env, DB: captureSessionDb };
+		// Hit the homepage (non-API) — should NOT call withSession.
+		await handleRequest(req('http://localhost:8787/'), fakeEnv, fakeLogger, null);
+		expect(calls).toEqual([]);
+	});
+
+	it('back-compat: works when env.DB has no withSession (e.g. older Miniflare)', async () => {
+		// Strip withSession to simulate an old runtime / fallback path.
+		const strippedDb = Object.create(null);
+		Object.assign(strippedDb, {
+			prepare: env.DB.prepare.bind(env.DB),
+			batch: env.DB.batch.bind(env.DB),
+		});
+		const fakeEnv = { ...env, DB: strippedDb };
+		const response = await handleRequest(
+			req('http://localhost:8787/api/user'),
+			fakeEnv,
+			fakeLogger,
+			null,
+		);
+		expect(response.status).toBe(200);
+		// No session = no bookmark header.
+		expect(response.headers.get('x-d1-bookmark')).toBeNull();
+	});
+
+	it('a writes session lets a subsequent read in the same request see the write (read-after-write)', async () => {
+		// This is the core property D1 Sessions exists to provide. In our worker
+		// it manifests through any handler that writes then reads (e.g. createLink
+		// inserts then returns the row). Here we exercise it directly through dbRun.
+		const session = env.DB.withSession('first-unconstrained');
+		const sessionEnv = { ...env, DB: session };
+		const now = new Date().toISOString();
+		await dbRun(
+			sessionEnv,
+			`INSERT INTO links (shortcode, owner_id, url, created, updated, clicks) VALUES (?, ?, ?, ?, ?, 0)`,
+			['raw-rb', 'gh:rb', 'https://example.com', now, now],
+		);
+		const { dbGet } = await import('../src/db.js');
+		const row = await dbGet(sessionEnv, `SELECT shortcode, url FROM links WHERE shortcode = ?`, ['raw-rb']);
+		expect(row).toBeTruthy();
+		expect(row.shortcode).toBe('raw-rb');
+		expect(row.url).toBe('https://example.com');
+	});
+});

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -91,10 +91,6 @@
 		}
 	],
 	"vars": {
-		// Matches the Access JWT email-derived login (payload.email.split('@')[0]).
-		// Sprint 2a moved identity from GitHub login (was 'mackhaymond') to Access
-		// email username part ('mack.haymond' for mack.haymond@icloud.com).
-		"AUTHORIZED_USER": "mack.haymond",
 		"SESSION_MAX_AGE": "28800",
 		"SESSION_COOKIE_NAME": "__Host-link_session",
 		"ALLOWED_ORIGINS": "https://link.mackhaymond.co",
@@ -175,7 +171,6 @@
 				"AUTH_DISABLED": "true",
 				"ENVIRONMENT": "development",
 				"SESSION_ALLOW_INSECURE_COOKIES": "false",
-				"AUTHORIZED_USER": "mack.haymond",
 				"SESSION_MAX_AGE": "28800",
 				"SESSION_COOKIE_NAME": "__Host-link_session",
 				"ALLOWED_ORIGINS": "https://worker-staging.<your-subdomain>.workers.dev",

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -49,6 +49,47 @@
 			"database_id": "359a73e4-5445-41d3-ab10-2dc6f3bbc2f1"
 		}
 	],
+	// B1: Native Cloudflare Rate-Limit bindings (Sprint 2b). Replaces the
+	// hand-rolled counters-table limiter (`isRateLimitedPersistent` in
+	// utils.js). Limits are per-Cloudflare-location (eventually consistent
+	// across PoPs) and free — see SECURITY.md for the trade-off note.
+	//
+	// `simple.period` is restricted to 10 or 60 seconds by the binding API.
+	// The previous in-DB limiter used 1-hour windows; we collapsed each
+	// limit to a 60s window with a more-lenient burst budget (rather than
+	// a literal 1/60th conversion that would have been too strict for
+	// real admin use). Effective ceilings:
+	//   - LINKS_CREATE   10/min  (was 50/hr  → ~12x more lenient sustained)
+	//   - LINKS_MUTATE   30/min  (was 200/hr → ~9x  more lenient sustained)
+	//   - LINKS_BULK     10/min  (was 50/hr  → ~12x more lenient sustained)
+	//   - PASSWORD_VERIFY 10/min (unchanged — already 10/min per-shortcode)
+	//
+	// namespace_id values are account-scoped integers (as strings). They
+	// must be unique per binding unless you intentionally want two
+	// bindings to share counters. Picked 2001-2004 to leave 1000s free
+	// for future bindings.
+	"ratelimits": [
+		{
+			"name": "RL_LINKS_CREATE",
+			"namespace_id": "2001",
+			"simple": { "limit": 10, "period": 60 }
+		},
+		{
+			"name": "RL_LINKS_MUTATE",
+			"namespace_id": "2002",
+			"simple": { "limit": 30, "period": 60 }
+		},
+		{
+			"name": "RL_LINKS_BULK",
+			"namespace_id": "2003",
+			"simple": { "limit": 10, "period": 60 }
+		},
+		{
+			"name": "RL_PASSWORD_VERIFY",
+			"namespace_id": "2004",
+			"simple": { "limit": 10, "period": 60 }
+		}
+	],
 	"vars": {
 		// Matches the Access JWT email-derived login (payload.email.split('@')[0]).
 		// Sprint 2a moved identity from GitHub login (was 'mackhaymond') to Access
@@ -95,6 +136,32 @@
 					"binding": "DB",
 					"database_name": "mack-link-staging",
 					"database_id": "ca9836da-1d7d-4c79-99cd-5c2734327b64"
+				}
+			],
+			// B1: Staging gets its own rate-limit namespaces (3001-3004) so
+			// burst PR-preview traffic doesn't share counters with prod.
+			// Same limits as prod since the binding is free regardless of
+			// namespace count.
+			"ratelimits": [
+				{
+					"name": "RL_LINKS_CREATE",
+					"namespace_id": "3001",
+					"simple": { "limit": 10, "period": 60 }
+				},
+				{
+					"name": "RL_LINKS_MUTATE",
+					"namespace_id": "3002",
+					"simple": { "limit": 30, "period": 60 }
+				},
+				{
+					"name": "RL_LINKS_BULK",
+					"namespace_id": "3003",
+					"simple": { "limit": 10, "period": 60 }
+				},
+				{
+					"name": "RL_PASSWORD_VERIFY",
+					"namespace_id": "3004",
+					"simple": { "limit": 10, "period": 60 }
 				}
 			],
 			"assets": {


### PR DESCRIPTION
# Sprint 2b: perf + security polish + identity cleanup

Builds on Sprint 1 (Static Assets, cron, PR previews) and Sprint 2a (Cloudflare Access migration). Four work items, all green on local validation; CI will exercise the rest.

## What changed

### B1 - Native Cloudflare Rate-Limit binding (`feat/rate-limit`)
- 4 `ratelimits` bindings in `wrangler.jsonc` (prod 2001-2004, staging 3001-3004), each `simple.period: 60`
- `worker/src/rateLimit.js` wraps `env.RL_*.limit({ key })` with fail-open semantics + a 429 response builder
- 6 callsites in `routesLinks.js` + `routes/password.js` migrated; ~80 LOC of D1-counters code deleted
- `cleanupExpiredCounters` renamed -> `cleanupExpiredPasswordSessions` (counters table still backs password sessions)
- **Window semantics change**: prior 1-hour windows collapsed to 60s with burst-lenient limits (10/min create, 30/min mutate, 10/min bulk, 10/min pwd verify). The binding API only supports 10s or 60s. Documented in `wrangler.jsonc` + `SECURITY.md`.

### B2 - D1 Sessions API + read replication (`feat/db-sessions`)
- `/api/*` requests now wrap in `env.DB.withSession(bookmark)`; the admin client round-trips an `x-d1-bookmark` request/response header
- Hot path (redirect / analytics) stays on raw `env.DB` -- those paths are eventually consistent by design
- `db.js` helpers unchanged (sessions are API-compatible with `D1Database`)
- Works whether or not read replication is enabled
- WARP.md documents the bookmark header

**You will need to:** Cloudflare dashboard -> Workers & Pages -> D1 -> `mack-link` -> Settings -> **Enable Read Replication** (free, instant, no downtime). Same for `mack-link-staging`. The code path ships without it.

### B3 - Nonce-based CSP on Worker-rendered HTML (`fix/csp`)
- Drops `'unsafe-inline'` from `style-src` + `script-src` for password prompt, redirect error pages, marketing homepage
- Per-request nonce minted via `crypto.randomUUID()`, threaded into the render function AND the `Content-Security-Policy` header on the response
- `securityHeaders.js` is now idempotent: if a response already has a CSP, leave it alone (Worker-rendered HTML opts in)
- Admin SPA (served via `env.ASSETS`) keeps the default `'unsafe-inline'` CSP -- the Vite bundle inlines a small bootstrap and we can't reach into the build to inject per-request nonces

### B4 - Identity + cleanup carry-overs
- **B4a**: Drop the redundant `AUTHORIZED_USER` check in `requireAuth`. Access's Allow policy is the single source of truth (the prior double-source check already bit us in Sprint 2a's postmortem). Var removed from `wrangler.jsonc`, `config.js`, `ci.yml` migrations step.
- **B4b**: `user.login` is now the full email (no more `split('@')[0]`). Three failure modes the plan flagged are fixed: plus-addressing, cross-domain collision, ugly `gh:` owner_id prefix. `users.js` -> `owner_id` IS the email.
- **B4c**: CI staging deploy step: dead `JWT_SECRET` env block removed.
- **B4d**: `docs/API.md` auth section rewritten to reference Cloudflare Access; obsolete GitHub OAuth flow endpoints deleted from the doc.

## Migration steps (after merge)

1. **D1 read replication (optional, free, no downtime)**: Cloudflare dashboard -> D1 -> `mack-link` -> Settings -> Enable Read Replication. Repeat for `mack-link-staging`.

2. **Owner ID rename for prod D1** (only required if existing data has `gh:*` owner_id rows; safe no-op if not):
   ```bash
   OWNER_EMAIL=mack.haymond@icloud.com npm run db:apply:prod
   ```
   If your existing prod data has a legacy `gh:` local-part that doesn't match the email local-part (e.g. `gh:mackhaymond` vs `mack.haymond@icloud.com`), pass the explicit override:
   ```bash
   OLD_OWNER_ID=gh:mackhaymond OWNER_EMAIL=mack.haymond@icloud.com npm run db:apply:prod
   ```
   You can verify what's in prod first:
   ```bash
   npm run db:q:prod --sql="SELECT id FROM users; SELECT DISTINCT owner_id FROM links;"
   ```
   The migration is idempotent. It logs exactly what it will rename before doing the destructive UPDATE. Skips with a log line if no rename is needed.

3. **Optional, still pending from Sprint 2a**: Cloudflare Access dashboard -> add a **Bypass Application** for `link.mackhaymond.co/api/password/verify` so anonymous visitors hitting password-protected short links don't get the Access login page. (`validate:prod` currently warns about this; B1-B4 are orthogonal to it.)

## Verification

Local (with `npm run dev:ai` running against a clean local D1):
- `npm run lint` -> 0 errors (8 pre-existing warnings, all unrelated)
- `npm test` -> **134 / 134** passing (was 103 pre-PR; +31 new tests: 11 rateLimit, 6 sessions, 10 csp, 4 auth identity)
- `npm run build` -> clean
- `npm run validate:local` -> **15 / 15** passing
- Manual smoke (against `npm run dev:ai`):
  - 11th+ POST to `/api/links` returns 429 (B1 rate-limit binding fires)
  - `/api/*` responses include `x-d1-bookmark: ...` header (B2)
  - `/this-does-not-exist` response has `Content-Security-Policy: ... 'nonce-XXX' ...` matching `<style nonce="XXX">` in the body, no `'unsafe-inline'` (B3)

## Out of scope (explicit)
- Per-PR isolated preview deploys (Vercel-style) -- deferred
- Schema rebuild to drop the `users.github_login` UNIQUE constraint -- the column is now a generic display string but the constraint is harmless; rename + drop is a separate sprint
- Anything beyond the four B-items above

## Commit pattern

7 atomic commits (5 sprint items + 2 follow-up fixes to the migration runner needed during local validation):

```
feat(rate-limit): use native Cloudflare rate-limit binding (B1)
feat(db): adopt D1 Sessions API for read-after-write consistency (B2)
fix(csp): nonce-based CSP on Worker-rendered HTML; drop unsafe-inline (B3)
refactor(auth): drop redundant AUTHORIZED_USER check; use full email identity (B4a, B4b)
chore(ci): remove dead JWT_SECRET injection + update API.md (B4c, B4d)
fix(migrate): skip comment-only migration files
feat(migrate): support raw OLD/NEW_OWNER_ID rename for synthetic identities
```
